### PR TITLE
Add automated merge conflict labeling workflow

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,29 @@
+name: Label Merge Conflicts
+
+on:
+  push:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs with merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "PR has merge conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+            ⚠️ **This PR has merge conflicts.**
+
+            Please resolve the merge conflicts before review.
+
+            Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
+
+            📺 Watch this video to understand why conflicts occur and how to resolve them:
+            https://www.youtube.com/watch?v=Sqsz1-o7nXk


### PR DESCRIPTION
## Summary

This PR introduces an automated workflow that labels pull requests with merge conflicts using `eps1lon/actions-label-merge-conflict`.

When a PR has merge conflicts:

* A label **“PR has merge conflicts”** is automatically added.
* A comment is posted notifying the contributor.
* The label is automatically removed once conflicts are resolved.


## Why This Change?

Currently, maintainers must manually identify and notify contributors when their PR requires rebasing. This creates unnecessary review overhead and delays.

This workflow:

* Improves PR triage visibility
* Notifies contributors immediately when conflicts arise
* Reduces manual maintainer intervention
* Ensures PRs are conflict-free before review

## Behavior

### When merge conflicts appear:

* Label added: **PR has merge conflicts**
* Comment posted:

> ⚠️ This PR has merge conflicts.
> Please resolve the merge conflicts before review.
> Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
> Watch this video to understand why conflicts occur and how to resolve them.

### When conflicts are resolved:

* Label is automatically removed.

## Testing

The full lifecycle was tested in an isolated test repository:

* Conflict created → label + comment added
* Conflict resolved → label removed
* Subsequent base merges → re-check works correctly

## Screenshots

<img width="483" height="240" alt="Screenshot 2026-02-16 221209" src="https://github.com/user-attachments/assets/62969afa-07ba-4004-aa58-c43b65fdb210" />
<img width="640" height="392" alt="Screenshot 2026-02-16 221254" src="https://github.com/user-attachments/assets/9804b4cc-50ad-4543-afe1-d1995067b94a" />



## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.