### PR TITLE
feature: add GitHub organization explorer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,280 +1,69 @@
+
 <!-- Don't delete it -->
 <div name="readme-top"></div>
 
-<!-- Organization Logo -->
-<div align="center" style="display: flex; align-items: center; justify-content: center; gap: 16px;">
-  <img alt="AOSSIE" src="public/aossie-logo.svg" width="175">
-  <img src="public/todo-project-logo.svg" width="175" />
-</div>
-
-&nbsp;
-
-<!-- Organization Name -->
 <div align="center">
-
-[![Static Badge](https://img.shields.io/badge/aossie.org/TODO-228B22?style=for-the-badge&labelColor=FFC517)](https://TODO.aossie.org/)
-
-<!-- Correct deployed url to be added -->
-
+  <img alt="AOSSIE" src="public/aossie-logo.svg" width="120">
 </div>
 
-<!-- Organization/Project Social Handles -->
 <p align="center">
-<!-- Telegram -->
-<a href="https://t.me/StabilityNexus">
-<img src="https://img.shields.io/badge/Telegram-black?style=flat&logo=telegram&logoColor=white&logoSize=auto&color=24A1DE" alt="Telegram Badge"/></a>
-&nbsp;&nbsp;
-<!-- X (formerly Twitter) -->
-<a href="https://x.com/aossie_org">
-<img src="https://img.shields.io/twitter/follow/aossie_org" alt="X (formerly Twitter) Badge"/></a>
-&nbsp;&nbsp;
-<!-- Discord -->
-<a href="https://discord.gg/hjUhu33uAn">
-<img src="https://img.shields.io/discord/1022871757289422898?style=flat&logo=discord&logoColor=white&logoSize=auto&label=Discord&labelColor=5865F2&color=57F287" alt="Discord Badge"/></a>
-&nbsp;&nbsp;
-<!-- Medium -->
-<a href="https://news.stability.nexus/">
-  <img src="https://img.shields.io/badge/Medium-black?style=flat&logo=medium&logoColor=black&logoSize=auto&color=white" alt="Medium Badge"></a>
-&nbsp;&nbsp;
-<!-- LinkedIn -->
-<a href="https://www.linkedin.com/company/aossie/">
-  <img src="https://img.shields.io/badge/LinkedIn-black?style=flat&logo=LinkedIn&logoColor=white&logoSize=auto&color=0A66C2" alt="LinkedIn Badge"></a>
-&nbsp;&nbsp;
-<!-- Youtube -->
-<a href="https://www.youtube.com/@StabilityNexus">
-  <img src="https://img.shields.io/youtube/channel/subscribers/UCZOG4YhFQdlGaLugr_e5BKw?style=flat&logo=youtube&logoColor=white&logoSize=auto&labelColor=FF0000&color=FF0000" alt="Youtube Badge"></a>
+  <a href="https://x.com/aossie_org">
+    <img src="https://img.shields.io/twitter/follow/aossie_org" alt="Twitter Badge"/>
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://discord.gg/hjUhu33uAn">
+    <img src="https://img.shields.io/discord/1022871757289422898?label=Discord" alt="Discord Badge"/>
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://www.linkedin.com/company/aossie/">
+    <img src="https://img.shields.io/badge/LinkedIn-blue" alt="LinkedIn Badge"/>
+  </a>
 </p>
 
 ---
 
 <div align="center">
-<h1>TODO: Project Name</h1>
+  <h1>OrgExplorer</h1>
 </div>
 
-[TODO](https://TODO.stability.nexus/) is a ... TODO: Project Description.
+OrgExplorer is a web-based frontend project under AOSSIE.  
+It provides a simple and clean interface to explore GitHub organization data.
 
 ---
+> 🚀 This project is actively maintained under AOSSIE and open for contributions.
 
 ## 🚀 Features
 
-TODO: List your main features here:
-
-- **Feature 1**: Description
-- **Feature 2**: Description
-- **Feature 3**: Description
-- **Feature 4**: Description
+- ⚡ React + TypeScript + Vite setup
+- 🎯 Clean and simple UI
+- 🧩 Beginner-friendly structure
+- 🔗 Ready for GitHub API integration
 
 ---
 
 ## 💻 Tech Stack
 
-TODO: Update based on your project
-
-### Frontend
-- React / Next.js / Flutter / React Native
+- React
 - TypeScript
-- TailwindCSS
-
-### Backend
-- Flask / FastAPI / Node.js / Supabase
-- Database: PostgreSQL / SQLite / MongoDB
-
-### AI/ML (if applicable)
-- LangChain / LangGraph / LlamaIndex
-- Google Gemini / OpenAI / Anthropic Claude
-- Vector Database: Weaviate / Pinecone / Chroma
-- RAG / Prompt Engineering / Agent Frameworks
-
-### Blockchain (if applicable)
-- Solidity / solana / cardano / ergo Smart Contracts
-- Hardhat / Truffle / foundry
-- Web3.js / Ethers.js / Wagmi
-- OpenZeppelin / alchemy / Infura
+- Vite
 
 ---
 
-## ✅ Project Checklist
-
-TODO: Complete applicable items based on your project type
-
-- [ ] **The protocol** (if applicable):
-   - [ ] has been described and formally specified in a paper.
-   - [ ] has had its main properties mathematically proven.
-   - [ ] has been formally verified.
-- [ ] **The smart contracts** (if applicable):
-   - [ ] were thoroughly reviewed by at least two knights of The Stable Order.
-   - [ ] were deployed to: [Add deployment details]
-- [ ] **The mobile app** (if applicable):
-   - [ ] has an _About_ page containing the Stability Nexus's logo and pointing to the social media accounts of the Stability Nexus.
-   - [ ] is available for download as a release in this repo.
-   - [ ] is available in the relevant app stores.
-- [ ] **The AI/ML components** (if applicable):
-   - [ ] LLM/model selection and configuration are documented.
-   - [ ] Prompts and system instructions are version-controlled.
-   - [ ] Content safety and moderation mechanisms are implemented.
-   - [ ] API keys and rate limits are properly managed.
-
----
-
-## 🔗 Repository Links
-
-TODO: Update with your repository structure
-
-1. [Main Repository](https://github.com/AOSSIE-Org/TODO)
-2. [Frontend](https://github.com/AOSSIE-Org/TODO/tree/main/frontend) (if separate)
-3. [Backend](https://github.com/AOSSIE-Org/TODO/tree/main/backend) (if separate)
-
----
-
-## 🏗️ Architecture Diagram
-
-TODO: Add your system architecture diagram here
-
-```
-[Architecture Diagram Placeholder]
-```
-
-You can create architecture diagrams using:
-- [Draw.io](https://draw.io)
-- [Excalidraw](https://excalidraw.com)
-- [Lucidchart](https://lucidchart.com)
-- [Mermaid](https://mermaid.js.org) (for code-based diagrams)
-
-Example structure to include:
-- Frontend components
-- Backend services
-- Database architecture
-- External APIs/services
-- Data flow between components
-
----
-
-## 🔄 User Flow
-
-TODO: Add user flow diagrams showing how users interact with your application
-
-```
-[User Flow Diagram Placeholder]
-```
-
-### Key User Journeys
-
-TODO: Document main user flows:
-
-1. **User Journey 1**: Description
-   - Step 1
-   - Step 2
-   - Step 3
-
-2. **User Journey 2**: Description
-   - Step 1
-   - Step 2
-   - Step 3
-
-3. **User Journey 3**: Description
-   - Step 1
-   - Step 2
-   - Step 3
-
----
-
-## �🍀 Getting Started
+## 📦 Getting Started
 
 ### Prerequisites
 
-TODO: List what developers need installed
+- Node.js (v18 or above)
+- npm
 
-- Node.js 18+ / Python 3.9+ / Flutter SDK
-- npm / yarn / pnpm
-- [Any specific tools or accounts needed]
+---
 
 ### Installation
 
-TODO: Provide detailed setup instructions
-
-#### 1. Clone the Repository
-
 ```bash
-git clone https://github.com/AOSSIE-Org/TODO.git
-cd TODO
-```
-
-#### 2. Install Dependencies
-
-```bash
+git clone https://github.com/AOSSIE-Org/OrgExplorer.git
+cd OrgExplorer
 npm install
-# or
-yarn install
-# or
-pnpm install
-```
-
-#### 3. Configure Environment Variables(.env.example)
-
-Create a `.env` file in the root directory:
-
-```env
-# Add your environment variables here
-API_KEY=your_api_key
-DATABASE_URL=your_database_url
-```
-
-#### 4. Run the Development Server
-
-```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-```
+>> 🚀 This project is actively being developed under AOSSIE.
 
-#### 5. Open your Browser
-
-Navigate to [http://localhost:3000](http://localhost:3000) to see the application.
-
-For detailed setup instructions, please refer to our [Installation Guide](./docs/INSTALL_GUIDE.md) (if you have one).
-
----
-
-## 📱 App Screenshots
-
-TODO: Add screenshots showcasing your application
-
-|  |  |  |
-|---|---|---|
-| Screenshot 1 | Screenshot 2 | Screenshot 3 |
-
----
-
-## 🙌 Contributing
-
-⭐ Don't forget to star this repository if you find it useful! ⭐
-
-Thank you for considering contributing to this project! Contributions are highly appreciated and welcomed. To ensure smooth collaboration, please refer to our [Contribution Guidelines](./CONTRIBUTING.md).
-
----
-
-## ✨ Maintainers
-
-TODO: Add maintainer information
-
-- [Maintainer Name](https://github.com/username)
-- [Maintainer Name](https://github.com/username)
-
----
-
-## 📍 License
-
-This project is licensed under the GNU General Public License v3.0.
-See the [LICENSE](LICENSE) file for details.
-
----
-
-## 💪 Thanks To All Contributors
-
-Thanks a lot for spending your time helping TODO grow. Keep rocking 🥂
-
-[![Contributors](https://contrib.rocks/image?repo=AOSSIE-Org/TODO)](https://github.com/AOSSIE-Org/TODO/graphs/contributors)
-
-© 2025 AOSSIE 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,70 @@
-import { useState } from "react";
-import "./App.css";
+import { useRef, useState } from "react";
+
+type GitHubOrg = {
+  avatar_url: string;
+  login: string;
+  description: string | null;
+  followers: number;
+  public_repos: number;
+};
 
 function App() {
   const [org, setOrg] = useState("");
-  const [orgData, setOrgData] = useState<any>(null);
+  const [orgData, setOrgData] = useState<GitHubOrg | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const fetchOrg = async () => {
-    if (!org) return;
+import { useRef } from "react";
 
-    setLoading(true);
-    setError("");
-    setOrgData(null);
+const abortRef = useRef<AbortController | null>(null);
 
-    try {
-      const res = await fetch(`https://api.github.com/orgs/${org}`);
-      if (!res.ok) {
-        throw new Error("Organization not found");
-      }
-      const data = await res.json();
-      setOrgData(data);
-    } catch (err: any) {
-      setError(err.message);
+const fetchOrg = async () => {
+  const orgName = org.trim();
+  if (!orgName) return;
+
+  abortRef.current?.abort();
+  const controller = new AbortController();
+  abortRef.current = controller;
+
+  setLoading(true);
+  setError("");
+  setOrgData(null);
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/orgs/${encodeURIComponent(orgName)}`,
+      { signal: controller.signal }
+    );
+
+    if (!res.ok) {
+      throw new Error("Organization not found");
     }
 
-    setLoading(false);
-  };
+    const data = await res.json();
+    setOrgData(data);
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    setError(err instanceof Error ? err.message : "Failed to fetch organization");
+  } finally {
+    if (!controller.signal.aborted) setLoading(false);
+  }
+};
 
   return (
     <div style={{ textAlign: "center", padding: "2rem" }}>
       <h1>OrgExplorer</h1>
 
       <input
-        type="text"
-        placeholder="Enter GitHub org (e.g. google)"
-        value={org}
-        onChange={(e) => setOrg(e.target.value)}
+       <label htmlFor="org-input" style={{ position: "absolute", left: "-9999px" }}>
+  GitHub organization
+</label>
+
+<input
+         id="org-input"
+         type="text"
+         placeholder="Enter GitHub org (e.g. google)"
+         value={org}
+         onChange={(e) => setOrg(e.target.value)}
         style={{ padding: "10px", width: "250px", marginRight: "10px" }}
       />
 
@@ -49,7 +77,10 @@ function App() {
 
       {orgData && (
         <div style={{ marginTop: "20px" }}>
-          <img src={orgData.avatar_url} width="100" />
+         <img
+          src={orgData.avatar_url}
+          width="100"
+          alt={`${orgData.login} avatar`} 
           <h2>{orgData.login}</h2>
           <p>{orgData.description}</p>
           <p>Followers: {orgData.followers}</p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,13 +14,21 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 const abortRef = useRef<AbortController | null>(null);
 
 const fetchOrg = async () => {
   const orgName = org.trim();
-  if (!orgName) return;
+  const orgName = org.trim();
+
+if (!orgName) {
+  abortRef.current?.abort();   // cancel previous request
+  setLoading(false);
+  setError("");
+  setOrgData(null);
+  return;
+}
 
   abortRef.current?.abort();
   const controller = new AbortController();
@@ -60,14 +68,15 @@ const fetchOrg = async () => {
 </label>
 
 <input
-         id="org-input"
-         type="text"
-         placeholder="Enter GitHub org (e.g. google)"
-         value={org}
-         onChange={(e) => setOrg(e.target.value)}
-        style={{ padding: "10px", width: "250px", marginRight: "10px" }}
-      />
+  id="org-input"
+  type="text"
+  placeholder="Enter GitHub org (e.g. google)"
+  value={org}
+  onChange={(e) => setOrg(e.target.value)}
+  style={{ padding: "10px", width: "250px", marginRight: "10px" }}
+/>
 
+      
       <button onClick={fetchOrg} style={{ padding: "10px" }}>
         Search
       </button>
@@ -77,14 +86,17 @@ const fetchOrg = async () => {
 
       {orgData && (
         <div style={{ marginTop: "20px" }}>
-         <img
-          src={orgData.avatar_url}
-          width="100"
-          alt={`${orgData.login} avatar`} 
-          <h2>{orgData.login}</h2>
-          <p>{orgData.description}</p>
-          <p>Followers: {orgData.followers}</p>
-          <p>Public Repos: {orgData.public_repos}</p>
+       <img
+  src={orgData.avatar_url}
+  width="100"
+  alt={`${orgData.login} avatar`}
+/>
+
+<h2>{orgData.login}</h2>
+<p>{orgData.description}</p>
+<p>Followers: {orgData.followers}</p>
+<p>Public Repos: {orgData.public_repos}</p>
+          
         </div>
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,9 +42,15 @@ function App() {
         { signal: controller.signal }
       );
 
-      if (!res.ok) {
-        throw new Error("Organization not found");
-      }
+     if (!res.ok) {
+  if (res.status === 404) {
+    throw new Error("Organization not found");
+  } else if (res.status === 403) {
+    throw new Error("Rate limit exceeded. Please try again later.");
+  } else {
+    throw new Error(`Request failed (${res.status})`);
+  }
+}
 
       const data = await res.json();
       setOrgData(data as GitHubOrg);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,89 +14,88 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-import { useRef, useState } from "react";
+  const abortRef = useRef<AbortController | null>(null);
 
-const abortRef = useRef<AbortController | null>(null);
+  const fetchOrg = async () => {
+    const orgName = org.trim();
 
-const fetchOrg = async () => {
-  const orgName = org.trim();
-  const orgName = org.trim();
-
-if (!orgName) {
-  abortRef.current?.abort();   // cancel previous request
-  setLoading(false);
-  setError("");
-  setOrgData(null);
-  return;
-}
-
-  abortRef.current?.abort();
-  const controller = new AbortController();
-  abortRef.current = controller;
-
-  setLoading(true);
-  setError("");
-  setOrgData(null);
-
-  try {
-    const res = await fetch(
-      `https://api.github.com/orgs/${encodeURIComponent(orgName)}`,
-      { signal: controller.signal }
-    );
-
-    if (!res.ok) {
-      throw new Error("Organization not found");
+    // ✅ handle empty input properly
+    if (!orgName) {
+      abortRef.current?.abort();
+      setLoading(false);
+      setError("");
+      setOrgData(null);
+      return;
     }
 
-    const data = await res.json();
-    setOrgData(data);
-  } catch (err: unknown) {
-    if (err instanceof DOMException && err.name === "AbortError") return;
-    setError(err instanceof Error ? err.message : "Failed to fetch organization");
-  } finally {
-    if (!controller.signal.aborted) setLoading(false);
-  }
-};
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError("");
+    setOrgData(null);
+
+    try {
+      const res = await fetch(
+        `https://api.github.com/orgs/${encodeURIComponent(orgName)}`,
+        { signal: controller.signal }
+      );
+
+      if (!res.ok) {
+        throw new Error("Organization not found");
+      }
+
+      const data = await res.json();
+      setOrgData(data as GitHubOrg);
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Failed to fetch organization");
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  };
 
   return (
     <div style={{ textAlign: "center", padding: "2rem" }}>
       <h1>OrgExplorer</h1>
 
+      {/* ✅ Accessible Label */}
+      <label htmlFor="org-input" style={{ position: "absolute", left: "-9999px" }}>
+        GitHub organization
+      </label>
+
+      {/* ✅ Input */}
       <input
-       <label htmlFor="org-input" style={{ position: "absolute", left: "-9999px" }}>
-  GitHub organization
-</label>
+        id="org-input"
+        type="text"
+        placeholder="Enter GitHub org (e.g. google)"
+        value={org}
+        onChange={(e) => setOrg(e.target.value)}
+        style={{ padding: "10px", width: "250px", marginRight: "10px" }}
+      />
 
-<input
-  id="org-input"
-  type="text"
-  placeholder="Enter GitHub org (e.g. google)"
-  value={org}
-  onChange={(e) => setOrg(e.target.value)}
-  style={{ padding: "10px", width: "250px", marginRight: "10px" }}
-/>
-
-      
+      {/* ✅ Button */}
       <button onClick={fetchOrg} style={{ padding: "10px" }}>
         Search
       </button>
 
+      {/* ✅ Loading & Error */}
       {loading && <p>Loading...</p>}
       {error && <p style={{ color: "red" }}>{error}</p>}
 
+      {/* ✅ Data Display */}
       {orgData && (
         <div style={{ marginTop: "20px" }}>
-       <img
-  src={orgData.avatar_url}
-  width="100"
-  alt={`${orgData.login} avatar`}
-/>
-
-<h2>{orgData.login}</h2>
-<p>{orgData.description}</p>
-<p>Followers: {orgData.followers}</p>
-<p>Public Repos: {orgData.public_repos}</p>
-          
+          <img
+            src={orgData.avatar_url}
+            width="100"
+            alt={`${orgData.login} avatar`}
+          />
+          <h2>{orgData.login}</h2>
+          <p>{orgData.description}</p>
+          <p>Followers: {orgData.followers}</p>
+          <p>Public Repos: {orgData.public_repos}</p>
         </div>
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,63 @@
-import './App.css'
+import { useState } from "react";
+import "./App.css";
 
 function App() {
+  const [org, setOrg] = useState("");
+  const [orgData, setOrgData] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchOrg = async () => {
+    if (!org) return;
+
+    setLoading(true);
+    setError("");
+    setOrgData(null);
+
+    try {
+      const res = await fetch(`https://api.github.com/orgs/${org}`);
+      if (!res.ok) {
+        throw new Error("Organization not found");
+      }
+      const data = await res.json();
+      setOrgData(data);
+    } catch (err: any) {
+      setError(err.message);
+    }
+
+    setLoading(false);
+  };
 
   return (
-    <>
-      <h1>Hello, OrgExplorer!</h1>
-    </>
-  )
+    <div style={{ textAlign: "center", padding: "2rem" }}>
+      <h1>OrgExplorer</h1>
+
+      <input
+        type="text"
+        placeholder="Enter GitHub org (e.g. google)"
+        value={org}
+        onChange={(e) => setOrg(e.target.value)}
+        style={{ padding: "10px", width: "250px", marginRight: "10px" }}
+      />
+
+      <button onClick={fetchOrg} style={{ padding: "10px" }}>
+        Search
+      </button>
+
+      {loading && <p>Loading...</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      {orgData && (
+        <div style={{ marginTop: "20px" }}>
+          <img src={orgData.avatar_url} width="100" />
+          <h2>{orgData.login}</h2>
+          <p>{orgData.description}</p>
+          <p>Followers: {orgData.followers}</p>
+          <p>Public Repos: {orgData.public_repos}</p>
+        </div>
+      )}
+    </div>
+  );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
## 🚀 GitHub Organization Explorer Feature

### Description

This PR adds a feature to search and display GitHub organization data using the GitHub API.

### Features

* Input field to enter organization name
* Fetch data from GitHub API
* Display organization details (avatar, name, description, followers, repos)
* Loading and error handling

### Why this change?

This aligns with the goal of OrgExplorer to provide an interface for exploring GitHub organizations.

### Screenshots

<img width="569" height="513" alt="Screenshot 2026-03-21 223849" src="https://github.com/user-attachments/assets/639edb33-2784-414e-a80c-2e468200caa7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization lookup: enter a GitHub organization name to fetch and display avatar, profile name, description, follower count, and public repo count.
  * Improved UX: loading and error states, previous results cleared on new searches, and overlapping requests are canceled so results remain current.

* **Documentation**
  * Streamlined README: rebranded to OrgExplorer with a simplified Getting Started and reduced auxiliary content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->