### PR TITLE
fix: move hook calls before early returns to comply with Rules of Hooks

### DIFF
--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -24,11 +24,6 @@ export default function AnalyticsPage() {
   const [granularity,   setGranularity]   = useState('monthly')
   const [selectedRepo,  setSelectedRepo]  = useState('All')
 
-  if (!model) return null
-
-  const repoNames = ['All', ...model.allRepos.slice(0, 12).map(r => r.name)]
-  const hasData   = Object.keys(issuesData || {}).length > 0
-
   const allIssues = useMemo(() => {
     const arr = []
     Object.values(issuesData || {}).forEach(issues => arr.push(...issues))
@@ -46,6 +41,10 @@ export default function AnalyticsPage() {
     [filteredIssues, granularity]
   )
 
+  if (!model) return null
+
+  const repoNames = ['All', ...model.allRepos.slice(0, 12).map(r => r.name)]
+  const hasData   = Object.keys(issuesData || {}).length > 0
   const hasSeries = series.length > 0
 
   return (

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -43,15 +43,10 @@ export default function ContributorsPage() {
       document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  if (!model) return null
-  const { contributors } = model
   const navigate = useNavigate()
+  const contributors = model?.contributors ?? []
 
   const busFactor = useMemo(() => computeBusFactor(contributors), [contributors])
-  const topActive = contributors.slice(0, 10).filter(c => c.freshness > 50).length
-  const freshPct = contributors.length ? Math.round(topActive / Math.min(10, contributors.length) * 100) : 0
-  const connectors = contributors.filter(c => c.isConnector)
-  const crossOrg = contributors.filter(c => c.isCrossOrg)
 
   const filtered = useMemo(() =>
     contributors.filter(c => !search || c.login.toLowerCase().includes(search.toLowerCase())),
@@ -59,6 +54,13 @@ export default function ContributorsPage() {
 
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'totalContribs', 'desc')
   const visible = sorted.slice(0, shown)
+
+  if (!model) return null
+
+  const topActive = contributors.slice(0, 10).filter(c => c.freshness > 50).length
+  const freshPct = contributors.length ? Math.round(topActive / Math.min(10, contributors.length) * 100) : 0
+  const connectors = contributors.filter(c => c.isConnector)
+  const crossOrg = contributors.filter(c => c.isCrossOrg)
 
   const riskColor = r => r === 'critical' ? 'var(--red)' : r === 'high' ? 'var(--amber)' : 'var(--green)'
   const riskBar = r => r === 'critical' ? '90%' : r === 'high' ? '60%' : '25%'

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -14,11 +14,6 @@ export default function GovernancePage() {
   const { model, issuesData, runAudit, govLoading } = useApp()
   const [tab, setTab] = useState('dead')
 
-  if (!model) return null
-
-  const hasAudit = Object.keys(issuesData || {}).length > 0
-  const daysSince = d => Math.floor((Date.now() - new Date(d)) / 86_400_000)
-
   // Flatten all issues and tag with repo/org
   const allIssues = useMemo(() => {
     const arr = []
@@ -28,6 +23,11 @@ export default function GovernancePage() {
     })
     return arr
   }, [issuesData])
+
+  if (!model) return null
+
+  const hasAudit = Object.keys(issuesData || {}).length > 0
+  const daysSince = d => Math.floor((Date.now() - new Date(d)) / 86_400_000)
 
   // Health check 1 — Dead Issues (>90 days open, not a PR)
   const deadIssues = allIssues

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -11,8 +11,6 @@ const fmt = n => n > 999 ? (n / 1000).toFixed(1) + 'k' : String(n)
 export default function OverviewPage() {
   const { orgs, model } = useApp()
   const navigate = useNavigate()
-  if (!model) return null
-
   const [open, setOpen] = useState(false)
   const infoRef = useRef(null)
 
@@ -27,6 +25,8 @@ export default function OverviewPage() {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [])
+
+  if (!model) return null
 
   const { allRepos } = model
   const isMulti = orgs.length > 1

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -37,8 +37,7 @@ export default function RepositoriesPage() {
   }, [])
 
   const navigate = useNavigate()
-  if (!model) return null
-  const { allRepos } = model
+  const allRepos = model?.allRepos ?? []
 
   const langs = useMemo(() =>
     ['All', ...new Set(allRepos.map(r => r.language).filter(Boolean))].slice(0, 10),
@@ -53,6 +52,8 @@ export default function RepositoriesPage() {
 
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'healthScore', 'desc')
   const visible = sorted.slice(0, shown)
+
+  if (!model) return null
 
   const TABLE_COLS = [
     ['name', 'Repository'],


### PR DESCRIPTION
**Addressed Issues:**
Fixes #75 

**changes**
Verified via grep on current main that all hooks appear before 
their respective guards after the fix:

File                      | Guard line | Last hook line |
--------------------------|------------|----------------|
OverviewPage.jsx          | L29        | L17 (useEffect)| 
RepositoriesPage.jsx      | L56        | L53 (useSortedData) |
ContributorsPage.jsx      | L58        | L55 (useSortedData) |
GovernancePage.jsx        | L27        | L18 (useMemo)  |
AnalyticsPage.jsx         | L44        | L39 (useMemo)  |

Production build: 1214 modules transformed, zero errors.
5 files changed, 22 insertions(+), 20 deletions(-)

**What was wrong**

Five page components were calling React hooks after an early 
`if (!model) return null` guard. React requires hooks to be called 
unconditionally on every render in the same order. When the app first 
loads, model is null so the component exits early, and those hooks are 
skipped. Once data loads, model gets a value, and those hooks suddenly 
run React detects the mismatch and throws:
Rendered more hooks than during the previous render.
This causes a crash in development and undefined behavior in production.

**What was changed**

Moved all hook calls above the guard in each of the five files.
Used optional chaining to handle null model safely in hooks that 
previously depended on model data:

- OverviewPage.jsx  :- moved useState, useRef, useEffect above guard
- RepositoriesPage.jsx :- moved useMemo ×2, useSortedData above guard;
  changed `model.allRepos` to `model?.allRepos ?? []`
- ContributorsPage.jsx :-  moved useNavigate, useMemo ×2, useSortedData 
  above guard; changed `model.contributors` to `model?.contributors ?? []`
- GovernancePage.jsx :- moved useMemo above guard
- AnalyticsPage.jsx:-  moved useMemo ×3 above guard

Non-hook variable assignments that reference model directly were left 
after the guard where they are safe.

**Why ESLint did not catch this**

The react-hooks/rules-of-hooks ESLint rule would normally flag this 
automatically, but eslint.config.js currently targets *.{ts,tsx} while 
all source files are .jsx/.js so linting never ran on these files. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal logic ordering across analytics, contributors, governance, overview, and repositories pages for improved performance efficiency.

---

**Note:** This release contains internal code improvements with no changes to user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->