### PR TITLE
fix: wire up API quota refresh button

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react'
 import { fetchOrg, fetchRepos, fetchContributors, fetchIssues, fetchRateLimit } from '../services/github'
+import { buildAnalyticalModel, getTopRepositories } from '../services/analytics'
 
 const Ctx = createContext(null)
 

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react'
-import { fetchOrg, fetchRepos, fetchContributors, fetchIssues, } from '../services/github'
+import { fetchOrg, fetchRepos, fetchContributors, fetchIssues, fetchRateLimit } from '../services/github'
 import { buildAnalyticalModel, getTopRepositories } from '../services/analytics'
 
 const Ctx = createContext(null)
@@ -34,6 +34,7 @@ export function AppProvider({ children }) {
   const [loadMsg, setLoadMsg] = useState('')
   const [govLoading, setGovLoading] = useState(false)
   const [error, setError] = useState('')
+  const [totalRepo, setTotalRepo] = useState(0)
 
   useEffect(() => {
     const handler = e => {
@@ -58,7 +59,11 @@ export function AppProvider({ children }) {
 
     return () => clearTimeout(timeout)
   }, [rateLimit])
-  const [totalRepo, setTotalRepo] = useState(0);
+
+  const refreshRateLimit = useCallback(async () => {
+    const rl = await fetchRateLimit(pat)
+    if (rl) setRateLimit(rl)
+  }, [pat])
   const savePat = useCallback(token => {
     setPat(token)
     token ? localStorage.setItem('oe_pat', token) : localStorage.removeItem('oe_pat')
@@ -140,7 +145,7 @@ export function AppProvider({ children }) {
     <Ctx.Provider value={{
       pat, savePat, orgs, model, issuesData,
       rateLimit, loading, loadMsg, govLoading, error, totalRepo,
-      explore, runAudit, setError,
+      explore, runAudit, setError, refreshRateLimit,
     }}>
       {children}
     </Ctx.Provider>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -62,7 +62,11 @@ export function AppProvider({ children }) {
 
   const refreshRateLimit = useCallback(async () => {
     const rl = await fetchRateLimit(pat)
-    if (rl) setRateLimit(rl)
+    if (rl) {
+      setRateLimit(rl)
+      return true
+    }
+    return false
   }, [pat])
   const savePat = useCallback(token => {
     setPat(token)

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -208,17 +208,34 @@ export default function SettingsPage() {
           <div style={C.card}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
               <div style={{ fontWeight: 600, fontSize: 15, letterSpacing: '.03em' }}>API Quota</div>
-              <FiRefreshCw 
-                size={14} 
-                color="var(--text2)" 
-                style={{ cursor: 'pointer', transition: 'transform 0.3s ease', transform: isRefreshing ? 'rotate(180deg)' : 'none' }} 
+              <button
+                type="button"
                 onClick={async () => {
                   if (isRefreshing) return;
                   setIsRefreshing(true);
                   await refreshRateLimit();
                   setTimeout(() => setIsRefreshing(false), 500); // Minimum spin duration for visual feedback
                 }}
-              />
+                style={{ 
+                  background: 'none', 
+                  border: 'none', 
+                  padding: '4px',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: '4px'
+                }}
+                aria-label="Refresh API Quota"
+                title="Refresh API Quota"
+                className="hover:bg-zinc-800 transition"
+              >
+                <FiRefreshCw 
+                  size={14} 
+                  color="var(--text2)" 
+                  style={{ transition: 'transform 0.3s ease', transform: isRefreshing ? 'rotate(180deg)' : 'none' }} 
+                />
+              </button>
             </div>
 
             {rateLimit ? (

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -5,11 +5,12 @@ import { C } from '../components/UI'
 import { cacheClear } from '../services/github'
 import { AiOutlineInfoCircle } from "react-icons/ai";
 export default function SettingsPage() {
-  const { pat, savePat, rateLimit } = useApp()
+  const { pat, savePat, rateLimit, refreshRateLimit } = useApp()
   const [draft, setDraft] = useState(pat)
   const [show, setShow] = useState(false)
   const [saved, setSaved] = useState(false)
   const [cleared, setCleared] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
 
   const handleSave = () => {
     savePat(draft.trim())
@@ -207,7 +208,17 @@ export default function SettingsPage() {
           <div style={C.card}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
               <div style={{ fontWeight: 600, fontSize: 15, letterSpacing: '.03em' }}>API Quota</div>
-              <FiRefreshCw size={14} color="var(--text2)" style={{ cursor: 'pointer' }} />
+              <FiRefreshCw 
+                size={14} 
+                color="var(--text2)" 
+                style={{ cursor: 'pointer', transition: 'transform 0.3s ease', transform: isRefreshing ? 'rotate(180deg)' : 'none' }} 
+                onClick={async () => {
+                  if (isRefreshing) return;
+                  setIsRefreshing(true);
+                  await refreshRateLimit();
+                  setTimeout(() => setIsRefreshing(false), 500); // Minimum spin duration for visual feedback
+                }}
+              />
             </div>
 
             {rateLimit ? (

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -213,8 +213,11 @@ export default function SettingsPage() {
                 onClick={async () => {
                   if (isRefreshing) return;
                   setIsRefreshing(true);
-                  await refreshRateLimit();
-                  setTimeout(() => setIsRefreshing(false), 500); // Minimum spin duration for visual feedback
+                  try {
+                    await refreshRateLimit();
+                  } finally {
+                    setTimeout(() => setIsRefreshing(false), 500); // Minimum spin duration for visual feedback
+                  }
                 }}
                 style={{ 
                   background: 'none', 

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -11,7 +11,7 @@ export default function SettingsPage() {
   const [saved, setSaved] = useState(false)
   const [cleared, setCleared] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
-
+  const [refreshError, setRefreshError] = useState(false)
   const handleSave = () => {
     savePat(draft.trim())
     setSaved(true)
@@ -210,11 +210,17 @@ export default function SettingsPage() {
               <div style={{ fontWeight: 600, fontSize: 15, letterSpacing: '.03em' }}>API Quota</div>
               <button
                 type="button"
+                disabled={isRefreshing}
                 onClick={async () => {
                   if (isRefreshing) return;
                   setIsRefreshing(true);
+                  setRefreshError(false);
                   try {
-                    await refreshRateLimit();
+                    const success = await refreshRateLimit();
+                    if (!success) {
+                      setRefreshError(true);
+                      setTimeout(() => setRefreshError(false), 2000);
+                    }
                   } finally {
                     setTimeout(() => setIsRefreshing(false), 500); // Minimum spin duration for visual feedback
                   }
@@ -230,12 +236,12 @@ export default function SettingsPage() {
                   borderRadius: '4px'
                 }}
                 aria-label="Refresh API Quota"
-                title="Refresh API Quota"
-                className="hover:bg-zinc-800 transition"
+                title={refreshError ? "Failed to refresh" : "Refresh API Quota"}
+                className="hover:bg-(--bg) transition"
               >
                 <FiRefreshCw 
                   size={14} 
-                  color="var(--text2)" 
+                  color={refreshError ? "var(--red)" : "var(--text2)"} 
                   style={{ transition: 'transform 0.3s ease', transform: isRefreshing ? 'rotate(180deg)' : 'none' }} 
                 />
               </button>


### PR DESCRIPTION
Fixes #78

### Description
Wired up the "dead" API Quota refresh button on the Settings page so that users can actually click it to fetch their updated GitHub rate limits without needing to trigger a full page reload or a new organization query.

### Solution
- Exported a new `refreshRateLimit` callback from `AppContext.jsx`.
- Attached the `onClick` handler to the `FiRefreshCw` icon in `SettingsPage.jsx`.
- Added a seamless CSS `transform: rotate` animation to provide visual feedback while the API call is in flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added an interactive “API Quota” refresh option on the Settings page. Click the refresh button to update your current rate limit with loading feedback and a short delay to prevent repeated simultaneous refresh actions.
  - If the refresh fails, an error indicator is shown and the refresh button is returned to its normal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->