### PR TITLE
feat: add contributor avatars with circular clipping and border

### DIFF
--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -93,10 +93,33 @@ export default function NetworkPage() {
           .attr('fill', healthColor(d.data.healthScore || 0))
           .attr('stroke', '#0d0d0d').attr('stroke-width', 1.5)
       } else {
+        const r = contribR(d.data.totalContribs || 1)
+
+        const clipId = `avatar-clip-${d.id}`
+
+        svg.append('defs')
+          .append('clipPath')
+          .attr('id', clipId)
+          .append('circle')
+          .attr('r', r)
+          .attr('cx', 0)
+          .attr('cy', 0)
+
+        // Avatar image
+        el.append('image')
+          .attr('href', d.data.avatar_url)
+          .attr('x', -r)
+          .attr('y', -r)
+          .attr('width', r * 2)
+          .attr('height', r * 2)
+          .attr('clip-path', `url(#${clipId})`)
+
+        // Border around avatar
         el.append('circle')
-          .attr('r', contribR(d.data.totalContribs || 1))
-          .attr('fill', d.data.isConnector ? '#f5c518' : '#555')
-          .attr('stroke', '#0d0d0d').attr('stroke-width', 1.5)
+          .attr('r', r)
+          .attr('fill', 'none')
+          .attr('stroke', d.data.isConnector ? '#f5c518' : '#555')
+          .attr('stroke-width', 2)
       }
       const labelY = d.type === 'repo'
         ? repoRadius(d.data.stargazers_count || 0) + 11


### PR DESCRIPTION
###  Screenshots/Recordings:
Before:
<img width="1071" height="784" alt="image" src="https://github.com/user-attachments/assets/a61e85ed-5e21-40a2-8b93-1f445b97f20e" />

After:
<img width="1205" height="746" alt="image" src="https://github.com/user-attachments/assets/0adb2790-3371-4320-b892-804888e3b35f" />


### Additional Notes:
This PR changes to show contributors avatar in Network tab for repo-contributor graph.
Previously this only shows a circle, but changes made in **src/pages/NetworkPage.jsx** to display the avatar of the contributor.

This change ensures better UX.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated contributor nodes in network visualization to display avatar images in circular frames instead of colored circles.
  * Added visual distinction for cross-repository connectors with specialized border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->