### PR TITLE
feat: integrate Social Share button into Overview page

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
 
     <link rel="preconnect" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://api.github.com" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@Aman-1/src/social-share-button.css" />
-    <script src="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@Aman-1/src/social-share-button.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@93ef0aeaa2be3a29f7a59708a8edb8bba107cab6/src/social-share-button.css" integrity="sha384-VwSR535+O4y8lpRAmHBBDrfpcoW4tPoeJFI3acttiuSWAJ4CShtBCi6heg3Va4pw" crossorigin="anonymous" />
+    <script defer src="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@93ef0aeaa2be3a29f7a59708a8edb8bba107cab6/src/social-share-button.js" integrity="sha384-oIU2y1c5kK/WldxfrH2dPJfBNa2Gor/iA5FdrzRzcC+cjZ/VUtmWNUO5V5L1cbMh" crossorigin="anonymous"></script>
 
     <script type="application/ld+json">
       {

--- a/index.html
+++ b/index.html
@@ -48,9 +48,9 @@
 
   <link rel="preconnect" href="https://api.github.com" />
   <link rel="dns-prefetch" href="https://api.github.com" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/KaranUnique/SocialShareButton/src/social-share-button.css"
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton/src/social-share-button.css"
     crossorigin="anonymous" />
-  <script defer src="https://cdn.jsdelivr.net/gh/KaranUnique/SocialShareButton/src/social-share-button.js"
+  <script defer src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton/src/social-share-button.js"
     crossorigin="anonymous"></script>
   <script type="application/ld+json">
       {

--- a/index.html
+++ b/index.html
@@ -77,6 +77,8 @@
 
     <link rel="preconnect" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://api.github.com" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@Aman-1/src/social-share-button.css" />
+    <script src="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@Aman-1/src/social-share-button.js"></script>
 
     <script type="application/ld+json">
       {

--- a/index.html
+++ b/index.html
@@ -1,86 +1,58 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0f172a" />
 
-    <title>
-      OrgExplorer — GitHub Organization Analytics & Repository Insights
-    </title>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0f172a" />
 
-    <meta
-      name="title"
-      content="OrgExplorer — GitHub Organization Analytics & Repository Insights"
-    />
+  <title>
+    OrgExplorer — GitHub Organization Analytics & Repository Insights
+  </title>
 
-    <meta
-      name="description"
-      content="Analyze GitHub organizations with repository insights, contributor intelligence, activity trends, governance analytics, and interactive visualizations using OrgExplorer."
-    />
+  <meta name="title" content="OrgExplorer — GitHub Organization Analytics & Repository Insights" />
 
-    <meta
-      name="keywords"
-      content="GitHub analytics, GitHub organization analytics, repository insights, contributor analytics, open source analytics, GitHub dashboard, repository metrics, contributor graph, OrgExplorer, GitHub data visualization, open source project analytics"
-    />
+  <meta name="description"
+    content="Analyze GitHub organizations with repository insights, contributor intelligence, activity trends, governance analytics, and interactive visualizations using OrgExplorer." />
 
-    <meta name="author" content="AOSSIE" />
-    <meta name="robots" content="index, follow" />
+  <meta name="keywords"
+    content="GitHub analytics, GitHub organization analytics, repository insights, contributor analytics, open source analytics, GitHub dashboard, repository metrics, contributor graph, OrgExplorer, GitHub data visualization, open source project analytics" />
 
-    <link rel="canonical" href="https://orgexplorer.aossie.org/" />
+  <meta name="author" content="AOSSIE" />
+  <meta name="robots" content="index, follow" />
 
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="/org-explorer-logo.svg"
-    />
-    <link rel="apple-touch-icon" href="/org-explorer-logo.png" />
+  <link rel="canonical" href="https://orgexplorer.aossie.org/" />
 
-    <meta property="og:type" content="website" />
+  <link rel="icon" type="image/svg+xml" href="/org-explorer-logo.svg" />
+  <link rel="apple-touch-icon" href="/org-explorer-logo.png" />
 
-    <meta
-      property="og:url"
-      content="https://orgexplorer.aossie.org/"
-    />
+  <meta property="og:type" content="website" />
 
-    <meta
-      property="og:title"
-      content="OrgExplorer — GitHub Organization Analytics"
-    />
+  <meta property="og:url" content="https://orgexplorer.aossie.org/" />
 
-    <meta
-      property="og:description"
-      content="Advanced GitHub organization analytics with repository insights, contributor intelligence, governance metrics, and interactive visualizations."
-    />
+  <meta property="og:title" content="OrgExplorer — GitHub Organization Analytics" />
 
-    <meta
-      property="og:image"
-      content="https://orgexplorer.aossie.org/og-image.png"
-    />
+  <meta property="og:description"
+    content="Advanced GitHub organization analytics with repository insights, contributor intelligence, governance metrics, and interactive visualizations." />
 
-    <meta name="twitter:card" content="summary_large_image" />
+  <meta property="og:image" content="https://orgexplorer.aossie.org/og-image.png" />
 
-    <meta
-      name="twitter:title"
-      content="OrgExplorer — GitHub Organization Analytics"
-    />
+  <meta name="twitter:card" content="summary_large_image" />
 
-    <meta
-      name="twitter:description"
-      content="Analyze GitHub organizations with advanced repository and contributor analytics."
-    />
+  <meta name="twitter:title" content="OrgExplorer — GitHub Organization Analytics" />
 
-    <meta
-      name="twitter:image"
-      content="https://orgexplorer.aossie.org/og-image.png"
-    />
+  <meta name="twitter:description"
+    content="Analyze GitHub organizations with advanced repository and contributor analytics." />
 
-    <link rel="preconnect" href="https://api.github.com" />
-    <link rel="dns-prefetch" href="https://api.github.com" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@93ef0aeaa2be3a29f7a59708a8edb8bba107cab6/src/social-share-button.css" integrity="sha384-VwSR535+O4y8lpRAmHBBDrfpcoW4tPoeJFI3acttiuSWAJ4CShtBCi6heg3Va4pw" crossorigin="anonymous" />
-    <script defer src="https://cdn.jsdelivr.net/gh/amankv1234/SocialShareButton@93ef0aeaa2be3a29f7a59708a8edb8bba107cab6/src/social-share-button.js" integrity="sha384-oIU2y1c5kK/WldxfrH2dPJfBNa2Gor/iA5FdrzRzcC+cjZ/VUtmWNUO5V5L1cbMh" crossorigin="anonymous"></script>
+  <meta name="twitter:image" content="https://orgexplorer.aossie.org/og-image.png" />
 
-    <script type="application/ld+json">
+  <link rel="preconnect" href="https://api.github.com" />
+  <link rel="dns-prefetch" href="https://api.github.com" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/KaranUnique/SocialShareButton/src/social-share-button.css"
+    crossorigin="anonymous" />
+  <script defer src="https://cdn.jsdelivr.net/gh/KaranUnique/SocialShareButton/src/social-share-button.js"
+    crossorigin="anonymous"></script>
+  <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebApplication",
@@ -96,13 +68,14 @@
         }
       }
     </script>
-  </head>
+</head>
 
-  <body>
-    <noscript> OrgExplorer requires JavaScript to run properly. </noscript>
+<body>
+  <noscript> OrgExplorer requires JavaScript to run properly. </noscript>
 
-    <div id="root"></div>
+  <div id="root"></div>
 
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -79,10 +79,23 @@ const SocialShareButton = ({
   ]);
 
   if (loadError) {
-    const handleFallbackCopy = () => {
-      if (onCopy) onCopy();
-      else navigator.clipboard?.writeText(url || 'https://orgexplorer.aossie.org/');
-      alert("Widget failed to load. Link copied to clipboard!");
+    const handleFallbackCopy = async () => {
+      try {
+        if (onCopy) {
+          await onCopy();
+        } else {
+          const fallbackUrl = url || 'https://orgexplorer.aossie.org/';
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(fallbackUrl);
+          } else {
+            throw new Error("Clipboard API not available");
+          }
+        }
+        alert("Widget failed to load. Link copied to clipboard!");
+      } catch (err) {
+        console.error("Failed to copy link: ", err);
+        alert("Widget failed to load. Failed to copy link.");
+      }
     };
 
     return (

--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -100,6 +100,7 @@ const SocialShareButton = ({
 
     return (
       <button
+        type="button"
         onClick={handleFallbackCopy}
         style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, border: '1px solid #ef4444', padding: '6px 12px', borderRadius: '6px', background: 'transparent', color: 'inherit', cursor: 'pointer' }}
         title="Social Share widget failed to load. Click to copy link."

--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -38,7 +38,7 @@ const SocialShareButton = ({
         setLoadError(false);
         shareButtonRef.current = new window.SocialShareButton({
           container: containerRef.current,
-          url: url || window.location.href,
+          url: url || 'https://orgexplorer.aossie.org/',
           title: title || document.title,
           description,
           hashtags,
@@ -81,7 +81,7 @@ const SocialShareButton = ({
   if (loadError) {
     const handleFallbackCopy = () => {
       if (onCopy) onCopy();
-      else navigator.clipboard?.writeText(url || window.location.href);
+      else navigator.clipboard?.writeText(url || 'https://orgexplorer.aossie.org/');
       alert("Widget failed to load. Link copied to clipboard!");
     };
 

--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -1,0 +1,73 @@
+import React, { useRef, useEffect } from 'react';
+
+const SocialShareButton = ({
+  url = '',
+  title = '',
+  description = '',
+  hashtags = [],
+  via = '',
+  platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit', 'pinterest'],
+  theme = 'dark',
+  buttonText = 'Share',
+  customClass = '',
+  onShare = null,
+  onCopy = null,
+  buttonStyle = 'default',
+  modalPosition = 'center',
+  buttonColor = '',
+  buttonHoverColor = '',
+  showButton = true,
+  analytics = true,
+  onAnalytics = null,
+  analyticsPlugins = [],
+  componentId = null,
+  debug = false,
+}) => {
+  const containerRef = useRef(null);
+  const shareButtonRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.SocialShareButton) {
+      shareButtonRef.current = new window.SocialShareButton({
+        container: containerRef.current,
+        url: url || window.location.href,
+        title: title || document.title,
+        description,
+        hashtags,
+        via,
+        platforms,
+        theme,
+        buttonText,
+        customClass,
+        onShare,
+        onCopy,
+        buttonStyle,
+        modalPosition,
+        buttonColor,
+        buttonHoverColor,
+        showButton,
+        analytics,
+        onAnalytics,
+        analyticsPlugins,
+        componentId,
+        debug,
+      });
+    }
+
+    return () => {
+      if (shareButtonRef.current) {
+        shareButtonRef.current.destroy();
+        shareButtonRef.current = null;
+      }
+    };
+  }, [
+    url, title, description, hashtags, via, platforms, theme, buttonText,
+    customClass, onShare, onCopy, buttonStyle, modalPosition, buttonColor,
+    buttonHoverColor, showButton, analytics, onAnalytics, analyticsPlugins,
+    componentId, debug
+  ]);
+
+  return <div ref={containerRef}></div>;
+};
+
+export default SocialShareButton;

--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -1,12 +1,17 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
+import { FiShare2 } from 'react-icons/fi';
+
+const DEFAULT_HASHTAGS = [];
+const DEFAULT_PLATFORMS = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit', 'pinterest'];
+const DEFAULT_ANALYTICS_PLUGINS = [];
 
 const SocialShareButton = ({
   url = '',
   title = '',
   description = '',
-  hashtags = [],
+  hashtags = DEFAULT_HASHTAGS,
   via = '',
-  platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit', 'pinterest'],
+  platforms = DEFAULT_PLATFORMS,
   theme = 'dark',
   buttonText = 'Share',
   customClass = '',
@@ -19,39 +24,45 @@ const SocialShareButton = ({
   showButton = true,
   analytics = true,
   onAnalytics = null,
-  analyticsPlugins = [],
+  analyticsPlugins = DEFAULT_ANALYTICS_PLUGINS,
   componentId = null,
   debug = false,
 }) => {
   const containerRef = useRef(null);
   const shareButtonRef = useRef(null);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && window.SocialShareButton) {
-      shareButtonRef.current = new window.SocialShareButton({
-        container: containerRef.current,
-        url: url || window.location.href,
-        title: title || document.title,
-        description,
-        hashtags,
-        via,
-        platforms,
-        theme,
-        buttonText,
-        customClass,
-        onShare,
-        onCopy,
-        buttonStyle,
-        modalPosition,
-        buttonColor,
-        buttonHoverColor,
-        showButton,
-        analytics,
-        onAnalytics,
-        analyticsPlugins,
-        componentId,
-        debug,
-      });
+    if (typeof window !== 'undefined') {
+      if (window.SocialShareButton) {
+        setLoadError(false);
+        shareButtonRef.current = new window.SocialShareButton({
+          container: containerRef.current,
+          url: url || window.location.href,
+          title: title || document.title,
+          description,
+          hashtags,
+          via,
+          platforms,
+          theme,
+          buttonText,
+          customClass,
+          onShare,
+          onCopy,
+          buttonStyle,
+          modalPosition,
+          buttonColor,
+          buttonHoverColor,
+          showButton,
+          analytics,
+          onAnalytics,
+          analyticsPlugins,
+          componentId,
+          debug,
+        });
+      } else {
+        setLoadError(true);
+      }
     }
 
     return () => {
@@ -66,6 +77,24 @@ const SocialShareButton = ({
     buttonHoverColor, showButton, analytics, onAnalytics, analyticsPlugins,
     componentId, debug
   ]);
+
+  if (loadError) {
+    const handleFallbackCopy = () => {
+      if (onCopy) onCopy();
+      else navigator.clipboard?.writeText(url || window.location.href);
+      alert("Widget failed to load. Link copied to clipboard!");
+    };
+
+    return (
+      <button
+        onClick={handleFallbackCopy}
+        style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, border: '1px solid #ef4444', padding: '6px 12px', borderRadius: '6px', background: 'transparent', color: 'inherit', cursor: 'pointer' }}
+        title="Social Share widget failed to load. Click to copy link."
+      >
+        <FiShare2 size={13} /> {buttonText} (Fallback)
+      </button>
+    );
+  }
 
   return <div ref={containerRef}></div>;
 };

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -94,6 +94,9 @@ export default function OverviewPage() {
           <SocialShareButton 
             theme="dark" 
             buttonStyle="ghost" 
+            title={isMulti ? `OrgExplorer: ${orgs.map(o => o.login).join(' + ')}` : `OrgExplorer: ${orgs[0]?.name || orgs[0]?.login}`}
+            description={isMulti ? `${orgs.length} organizations — combined portfolio view` : (orgs[0]?.description || `@${orgs[0]?.login}`)}
+            url={window.location.href}
           />
         </div>
       </div>

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -96,7 +96,6 @@ export default function OverviewPage() {
             buttonStyle="ghost" 
             title={isMulti ? `OrgExplorer: ${orgs.map(o => o.login).join(' + ')}` : `OrgExplorer: ${orgs[0]?.name || orgs[0]?.login}`}
             description={isMulti ? `${orgs.length} organizations — combined portfolio view` : (orgs[0]?.description || `@${orgs[0]?.login}`)}
-            url={window.location.href}
           />
         </div>
       </div>

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -4,6 +4,7 @@ import { FiExternalLink, FiShare2, FiArrowRight } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, StatCard, HealthBar } from '../components/UI'
 import { BsFillInfoSquareFill } from "react-icons/bs";
+import SocialShareButton from '../components/SocialShareButton';
 
 const LANG_COLORS = ['#22c55e', '#f5c518', '#3b82f6', '#ef4444', '#a855f7', '#f97316', '#06b6d4']
 const fmt = n => n > 999 ? (n / 1000).toFixed(1) + 'k' : String(n)
@@ -90,12 +91,10 @@ export default function OverviewPage() {
               <FiExternalLink size={13} /> View on GitHub
             </a>
           )}
-          <button
-            onClick={() => navigator.clipboard?.writeText(window.location.href)}
-            style={{ ...C.btn('ghost'), display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}
-          >
-            <FiShare2 size={13} /> Share
-          </button>
+          <SocialShareButton 
+            theme="dark" 
+            buttonStyle="ghost" 
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Description
Migrates and integrates the interactive Social Share button component from the Vue demo into the main React-based OrgExplorer application. The component is instantiated seamlessly using a React wrapper (`SocialShareButton.jsx`) around the vanilla JS package. This replaces the static clipboard-copy share button on the Overview page.

## Related issue
Fixes #85 

### JavaScript & React
- Added a `SocialShareButton` functional component wrapper using `useRef` and `useEffect` lifecycle hooks for instance initialization and cleanup.
- Refactored `src/pages/OverviewPage.jsx` to render the interactive share menu instead of the standard button.
- Injected required CSS and JS script globals into `index.html`.
- Cleaned up and deleted the obsolete `social-share-demo` directory.

## Screenshots 
<img width="1920" height="961" alt="Screenshot 2026-06-24 125004" src="https://github.com/user-attachments/assets/0e1fe66b-8059-421a-95fc-fab77905f63d" />

## Recording 

https://drive.google.com/file/d/1Wa4kV0kUwqIg2-_ykQM09nhUeBPR4Ar6/view?usp=sharing

## Checklist
- [x] `npm run build` passes 
- [x] Commits are understandable without reading every file
- [x] Branch is reasonably up to date with upstream
- [x] No unnecessary dependencies
- [x] No secrets or large artifacts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a social sharing button to the overview page to help users share org content with improved options and styling.
  * The page now loads the required social sharing assets in the browser to power the sharing experience.

* **Bug Fixes**
  * Replaced the prior clipboard-only share action with the new sharing flow.
  * Added a fallback so users can still copy/share the link if the external sharing widget cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->