### PR TITLE
refactor: simplify SocialShareButton – remove client‑side fallback UI

### DIFF
--- a/src/components/SocialShareButton.jsx
+++ b/src/components/SocialShareButton.jsx
@@ -1,5 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { FiShare2 } from 'react-icons/fi';
+import React, { useRef, useEffect } from 'react';
 
 const DEFAULT_HASHTAGS = [];
 const DEFAULT_PLATFORMS = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit', 'pinterest'];
@@ -16,7 +15,6 @@ const SocialShareButton = ({
   buttonText = 'Share',
   customClass = '',
   onShare = null,
-  onCopy = null,
   buttonStyle = 'default',
   modalPosition = 'center',
   buttonColor = '',
@@ -30,41 +28,35 @@ const SocialShareButton = ({
 }) => {
   const containerRef = useRef(null);
   const shareButtonRef = useRef(null);
-  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      if (window.SocialShareButton) {
-        setLoadError(false);
-        shareButtonRef.current = new window.SocialShareButton({
-          container: containerRef.current,
-          url: url || 'https://orgexplorer.aossie.org/',
-          title: title || document.title,
-          description,
-          hashtags,
-          via,
-          platforms,
-          theme,
-          buttonText,
-          customClass,
-          onShare,
-          onCopy,
-          buttonStyle,
-          modalPosition,
-          buttonColor,
-          buttonHoverColor,
-          showButton,
-          analytics,
-          onAnalytics,
-          analyticsPlugins,
-          componentId,
-          debug,
-        });
-      } else {
-        setLoadError(true);
-      }
+    if (typeof window !== 'undefined' && window.SocialShareButton) {
+      shareButtonRef.current = new window.SocialShareButton({
+        container: containerRef.current,
+        url: url || 'https://orgexplorer.aossie.org/',
+        title: title || document.title,
+        description,
+        hashtags,
+        via,
+        platforms,
+        theme,
+        buttonText,
+        customClass,
+        onShare,
+        buttonStyle,
+        modalPosition,
+        buttonColor,
+        buttonHoverColor,
+        showButton,
+        analytics,
+        onAnalytics,
+        analyticsPlugins,
+        componentId,
+        debug,
+      });
+    } else {
+      console.warn('SocialShareButton widget not loaded');
     }
-
     return () => {
       if (shareButtonRef.current) {
         shareButtonRef.current.destroy();
@@ -73,42 +65,10 @@ const SocialShareButton = ({
     };
   }, [
     url, title, description, hashtags, via, platforms, theme, buttonText,
-    customClass, onShare, onCopy, buttonStyle, modalPosition, buttonColor,
+    customClass, onShare, buttonStyle, modalPosition, buttonColor,
     buttonHoverColor, showButton, analytics, onAnalytics, analyticsPlugins,
-    componentId, debug
+    componentId, debug,
   ]);
-
-  if (loadError) {
-    const handleFallbackCopy = async () => {
-      try {
-        if (onCopy) {
-          await onCopy();
-        } else {
-          const fallbackUrl = url || 'https://orgexplorer.aossie.org/';
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            await navigator.clipboard.writeText(fallbackUrl);
-          } else {
-            throw new Error("Clipboard API not available");
-          }
-        }
-        alert("Widget failed to load. Link copied to clipboard!");
-      } catch (err) {
-        console.error("Failed to copy link: ", err);
-        alert("Widget failed to load. Failed to copy link.");
-      }
-    };
-
-    return (
-      <button
-        type="button"
-        onClick={handleFallbackCopy}
-        style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, border: '1px solid #ef4444', padding: '6px 12px', borderRadius: '6px', background: 'transparent', color: 'inherit', cursor: 'pointer' }}
-        title="Social Share widget failed to load. Click to copy link."
-      >
-        <FiShare2 size={13} /> {buttonText} (Fallback)
-      </button>
-    );
-  }
 
   return <div ref={containerRef}></div>;
 };


### PR DESCRIPTION
## 📌 Summary
This PR simplifies the `SocialShareButton` component by removing client‑side error‑fallback UI and unused dependencies. The component now:
- Imports only `useRef` and `useEffect`.
- Drops the `onCopy` prop and related fallback logic.
- Initializes the external widget only when it is present, otherwise logs a warning.
- Returns a plain `<div ref={containerRef}></div>` for the widget to mount into.

## ✅ Why this change?
- Keeps the client repository minimal and avoids duplicate error handling that belongs in the widget library.
- Reduces bundle size (no extra icon or state handling).
- Aligns with maintainer’s request to keep the client side lightweight.

## 🔧 Issue
Closes #88 

## 📦 Testing
- Run `npm run dev` and verify the “Share” button still works on pages that load the widget.
- When the widget fails to load, the console now shows a warning instead of rendering a fallback button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social sharing widget initialization and handling when the widget is unavailable.
  * Removed the alternate fallback share action, so the component now relies on the primary sharing widget and shows a warning if it is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->