### PR TITLE
fix: update top repos selection to include all repositories

### DIFF
--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -27,7 +27,7 @@ export default function NetworkPage() {
     svg.attr('viewBox', `0 0 ${W} ${H}`)
 
     // Top repos and contributors for performance
-    const topRepos    = model.allRepos.slice(0, 30)
+    const topRepos    = model.allRepos
     const topContribs = model.contributors
 
     const nodes = []


### PR DESCRIPTION

###  Screenshots/Recordings:
Before: -
<img width="1763" height="1187" alt="Screenshot_3-7-2026_18196_localhost" src="https://github.com/user-attachments/assets/a14923e5-9fce-4d86-974f-2b6403e850c8" />

After: -
<img width="1763" height="1187" alt="Screenshot_3-7-2026_181932_localhost" src="https://github.com/user-attachments/assets/59a77fd8-b820-4cd8-bce6-2f6ee8ba4b1c" />

###  Additional Notes:
Fix network page to include all the repos when PAT is available.


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The network visualization now includes the full repository list instead of only a limited subset, so the displayed connections and nodes better reflect the complete dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->