### PR TITLE
Revert "fix: update top repos selection to include all repositories"

### DIFF
--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -27,7 +27,7 @@ export default function NetworkPage() {
     svg.attr('viewBox', `0 0 ${W} ${H}`)
 
     // Top repos and contributors for performance
-    const topRepos    = model.allRepos
+    const topRepos    = model.allRepos.slice(0, 30)
     const topContribs = model.contributors
 
     const nodes = []


### PR DESCRIPTION
Reverts AOSSIE-Org/OrgExplorer#96 bcz for large org, this is too heavy to display data for all repos.