### PR TITLE
fix: handle GitHub rate limit during governance audit

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -33,7 +33,8 @@ export function AppProvider({ children }) {
   const [loading, setLoading] = useState(false)
   const [loadMsg, setLoadMsg] = useState('')
   const [govLoading, setGovLoading] = useState(false)
-  const [error, setError] = useState('')
+  const [exploreError, setExploreError] = useState('')
+  const [auditError, setAuditError] = useState('')
   const [totalRepo, setTotalRepo] = useState(0)
 
   useEffect(() => {
@@ -75,7 +76,7 @@ export function AppProvider({ children }) {
 
   // Multi-org explore — core of Section 3.2.0
   const explore = useCallback(async orgNames => {
-    setLoading(true); setError(''); setModel(null); setOrgs([]); setIssuesData({})
+    setLoading(true); setExploreError(''); setModel(null); setOrgs([]); setIssuesData({}); setAuditError('')
     try {
       setLoadMsg('Fetching organization metadata...')
       const orgRes = await Promise.allSettled(orgNames.map(n => fetchOrg(n, pat)))
@@ -124,7 +125,7 @@ export function AppProvider({ children }) {
       localStorage.setItem('oe_recent', JSON.stringify([...new Set([entry, ...prev])].slice(0, 6)))
       return true
     } catch (err) {
-      setError(err.message === 'RATE_LIMIT'
+      setExploreError(err.message === 'RATE_LIMIT'
         ? 'GitHub API rate limit reached. Add a PAT in Settings for 5,000 req/hr.'
         : err.message)
       return false
@@ -137,10 +138,11 @@ export function AppProvider({ children }) {
   const runAudit = useCallback(async () => {
     if (!model || govLoading) return
     setGovLoading(true)
-    setError('')
+    setAuditError('')
     const map   = {}
     const repos = pat ? model.totalRepos : model.totalRepos.slice(0, 15)
     let rateLimitHit = false
+    const otherFailures = []
 
     // Batches of 5 using Promise.allSettled
     for (let i = 0; i < repos.length; i += 5) {
@@ -150,12 +152,20 @@ export function AppProvider({ children }) {
         map[`${repo.orgLogin}/${repo.name}`] = issues
       }))
 
-      // Check if any fetch in this batch hit the rate limit
-      const hitLimit = results.some(
-        r => r.status === 'rejected' && r.reason?.message === 'RATE_LIMIT'
-      )
-      if (hitLimit) {
-        rateLimitHit = true
+      for (let j = 0; j < results.length; j++) {
+        const result = results[j]
+        if (result.status === 'rejected') {
+          const msg = result.reason?.message
+          if (msg === 'RATE_LIMIT') {
+            rateLimitHit = true
+          } else {
+            // NOT_FOUND, HTTP_4xx/5xx, network failures, etc.
+            otherFailures.push(batch[j] ? `${batch[j].orgLogin}/${batch[j].name}` : 'unknown repo')
+          }
+        }
+      }
+
+      if (rateLimitHit) {
         break // no point continuing — remaining fetches will also fail
       }
     }
@@ -164,7 +174,9 @@ export function AppProvider({ children }) {
     setGovLoading(false)
 
     if (rateLimitHit) {
-      setError('GitHub API rate limit reached during audit. Results shown may be incomplete. Add a PAT in Settings for 5,000 req/hr.')
+      setAuditError('GitHub API rate limit reached during audit. Results shown may be incomplete. Add a PAT in Settings for 5,000 req/hr.')
+    } else if (otherFailures.length) {
+      setAuditError(`Audit completed with errors. Failed to fetch issues for: ${otherFailures.join(', ')}. Results may be incomplete.`)
     }
   }, [model, pat, govLoading])
 
@@ -205,8 +217,10 @@ export function AppProvider({ children }) {
   return (
     <Ctx.Provider value={{
       pat, savePat, orgs, model, issuesData,
-      rateLimit, loading, loadMsg, govLoading, error, totalRepo,
-      explore, runAudit, setError, refreshRateLimit, staleRepoStats,
+      rateLimit, loading, loadMsg, govLoading, totalRepo,
+      exploreError, setExploreError,
+      auditError, setAuditError,
+      explore, runAudit, refreshRateLimit, staleRepoStats,
     }}>
       {children}
     </Ctx.Provider>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -137,18 +137,35 @@ export function AppProvider({ children }) {
   const runAudit = useCallback(async () => {
     if (!model || govLoading) return
     setGovLoading(true)
+    setError('')
     const map   = {}
-    const repos = pat? model.totalRepos : model.totalRepos.slice(0, 15)
+    const repos = pat ? model.totalRepos : model.totalRepos.slice(0, 15)
+    let rateLimitHit = false
 
     // Batches of 5 using Promise.allSettled
     for (let i = 0; i < repos.length; i += 5) {
       const batch = repos.slice(i, i + 5)
-      await Promise.allSettled(batch.map(async repo => {
-        map[`${repo.orgLogin}/${repo.name}`] = await fetchIssues(repo.orgLogin, repo.name, pat)
+      const results = await Promise.allSettled(batch.map(async repo => {
+        const issues = await fetchIssues(repo.orgLogin, repo.name, pat)
+        map[`${repo.orgLogin}/${repo.name}`] = issues
       }))
+
+      // Check if any fetch in this batch hit the rate limit
+      const hitLimit = results.some(
+        r => r.status === 'rejected' && r.reason?.message === 'RATE_LIMIT'
+      )
+      if (hitLimit) {
+        rateLimitHit = true
+        break // no point continuing — remaining fetches will also fail
+      }
     }
+
     setIssuesData(map)
     setGovLoading(false)
+
+    if (rateLimitHit) {
+      setError('GitHub API rate limit reached during audit. Results shown may be incomplete. Add a PAT in Settings for 5,000 req/hr.')
+    }
   }, [model, pat, govLoading])
 
   const STALE_DAYS = 90

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -40,7 +40,7 @@ const getStatus = ratio => {
 }
 
 export default function GovernancePage() {
-  const { model, issuesData, runAudit, govLoading, staleRepoStats, error, setError } = useApp()
+  const { model, issuesData, runAudit, govLoading, staleRepoStats, auditError, setAuditError } = useApp()
   const [tab, setTab] = useState('dead')
 
   const ITEMS_PER_PAGE = 10
@@ -153,16 +153,20 @@ export default function GovernancePage() {
       />
 
       {/* Audit error banner */}
-      {error && (
-        <div style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          background: 'rgba(239,68,68,.08)', border: '1px solid rgba(239,68,68,.3)',
-          borderRadius: 8, padding: '10px 16px', marginBottom: 20,
-          fontSize: 13, color: 'var(--red)',
-        }}>
-          <span>{error}</span>
+      {auditError && (
+        <div
+          role="alert"
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            background: 'rgba(239,68,68,.08)', border: '1px solid rgba(239,68,68,.3)',
+            borderRadius: 8, padding: '10px 16px', marginBottom: 20,
+            fontSize: 13, color: 'var(--red)',
+          }}
+        >
+          <span>{auditError}</span>
           <button
-            onClick={() => setError('')}
+            type="button"
+            onClick={() => setAuditError('')}
             style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--red)', fontSize: 16, lineHeight: 1, padding: '0 4px' }}
             aria-label="Dismiss error"
           >

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -40,7 +40,7 @@ const getStatus = ratio => {
 }
 
 export default function GovernancePage() {
-  const { model, issuesData, runAudit, govLoading, staleRepoStats } = useApp()
+  const { model, issuesData, runAudit, govLoading, staleRepoStats, error, setError } = useApp()
   const [tab, setTab] = useState('dead')
 
   const ITEMS_PER_PAGE = 10
@@ -151,6 +151,25 @@ export default function GovernancePage() {
           </div>
         }
       />
+
+      {/* Audit error banner */}
+      {error && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          background: 'rgba(239,68,68,.08)', border: '1px solid rgba(239,68,68,.3)',
+          borderRadius: 8, padding: '10px 16px', marginBottom: 20,
+          fontSize: 13, color: 'var(--red)',
+        }}>
+          <span>{error}</span>
+          <button
+            onClick={() => setError('')}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--red)', fontSize: 16, lineHeight: 1, padding: '0 4px' }}
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {/* Summary stat cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 12, marginBottom: 24 }}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -7,7 +7,7 @@ import { C, Spinner } from '../components/UI'
 const QUICK = ['AOSSIE-Org', 'DjedAlliance', 'StabilityNexus']
 
 export default function HomePage() {
-  const { explore, loading, loadMsg, error } = useApp()
+  const { explore, loading, loadMsg, exploreError } = useApp()
   const navigate = useNavigate()
   const [input, setInput] = useState('')
   const [chips, setChips] = useState([])
@@ -89,7 +89,7 @@ export default function HomePage() {
         <p style={{ fontSize: 11, color: 'var(--text3)', marginTop: 6, paddingLeft: 4 }}>
           Type an org name and press Enter or comma to add. Add multiple orgs to analyze as a unified portfolio.
         </p>
-        {error && <p style={{ color: 'var(--red)', fontSize: 12, marginTop: 8 }}>{error}</p>}
+        {exploreError && <p style={{ color: 'var(--red)', fontSize: 12, marginTop: 8 }}>{exploreError}</p>}
       </div>
 
       {/* Loading */}


### PR DESCRIPTION
###  Addressed Issues:
Fixes #81 


###  Screenshots/Recordings:

<img width="1902" height="1031" alt="image" src="https://github.com/user-attachments/assets/99a8bcff-b3b4-4bc0-8a8e-e4969b1565eb" />

###  Additional Notes:

1. Promise.allSettled was absorbing rejected promises silently. The audit loop now inspects each batch's results for RATE_LIMIT rejections. On detection, the loop breaks early (avoiding further doomed requests) and calls setError() with a user-friendly message — the same pattern already used by explore().

2. error from AppContext was only rendered on HomePage. Since users are on the Governance page when the audit runs, the error was set but never shown. The page now reads error and setError from context and renders a dismissible inline banner between the page title and stat cards — scoped to where the user's attention is after clicking "Run Audit".

Partial results collected before the rate limit was hit are preserved and still displayed.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.
