### PR TITLE
fix: add safety guards for paginated GitHub API requests

### DIFF
--- a/src/services/github.js
+++ b/src/services/github.js
@@ -101,8 +101,10 @@ export async function fetchRepos(org, repoCount, pat) {
 export async function fetchContributors(org, repo, pat) {
   const all = []
   for(let page = 1; ; page++) {
+    if (page > 50) break
     const url = `https://api.github.com/repos/${org}/${repo}/contributors?per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
+    if (!Array.isArray(data)) break
     all.push(...data)
     if(data.length < 100) break
   }
@@ -112,8 +114,10 @@ export async function fetchContributors(org, repo, pat) {
 export async function fetchIssues(org, repo, pat) {
   const all = []
   for(let page = 1; ; page++) {
+    if (page > 50) break
     const url = `https://api.github.com/repos/${org}/${repo}/issues?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
+    if (!Array.isArray(data)) break
     all.push(...data)
     if(data.length < 100) break
   }

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -104,7 +104,10 @@ export async function fetchContributors(org, repo, pat) {
     if (page > 50) break
     const url = `https://api.github.com/repos/${org}/${repo}/contributors?per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
-    if (!Array.isArray(data)) break
+    if (!Array.isArray(data)) {
+      console.warn(`[fetchContributors] Unexpected response on page ${page} for ${org}/${repo}:`, data)
+      break
+    }
     all.push(...data)
     if(data.length < 100) break
   }
@@ -117,7 +120,10 @@ export async function fetchIssues(org, repo, pat) {
     if (page > 50) break
     const url = `https://api.github.com/repos/${org}/${repo}/issues?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
-    if (!Array.isArray(data)) break
+    if (!Array.isArray(data)) {
+      console.warn(`[fetchIssues] Unexpected response on page ${page} for ${org}/${repo}:`, data)
+      break
+    }
     all.push(...data)
     if(data.length < 100) break
   }


### PR DESCRIPTION
###  Addressed Issues:
Fixes #103 

###  Additional Notes:

fetchContributors and fetchIssues both used an unbounded for(let page = 1; ; page++) loop with no upper limit. If GitHub returned a malformed or non-array response (e.g. a rate-limit error object), data.length < 100 would never evaluate to true, causing an infinite loop and crashing the app.

Two guards were added to each function, placed at the top of the loop body before any data is consumed:

if (page > 50) break — hard cap at 50 pages (5,000 items max), consistent with the existing guard already present in fetchRepos.
if (!Array.isArray(data)) break — exits safely if the API returns anything other than an array (error object, rate-limit response, etc.), preventing the spread operator from throwing.

No behaviour changes for normal responses — the existing data.length < 100 early-exit still handles the happy path.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of contributors and issues so pagination stops safely after a large number of pages.
  * Added checks to handle unexpected response data more gracefully, reducing the chance of incomplete or broken results during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->