### PR TITLE
Feat analysis with and without pat

### DIFF
--- a/src/components/AnalysisBanner.jsx
+++ b/src/components/AnalysisBanner.jsx
@@ -3,6 +3,7 @@ import { FiLock, FiLoader, FiInfo, } from 'react-icons/fi'
 import { IoMdAnalytics } from "react-icons/io";
 import { useApp } from '../context/AppContext'
 import PATModal from './PATModal'
+import LearnMoreModal from './LearnModeModal'
 
 
 export default function AnalysisBanner({ page, description, onRun, loading = false, analysisStatus = 'sample', }) {
@@ -210,6 +211,10 @@ export default function AnalysisBanner({ page, description, onRun, loading = fal
       <PATModal
         open={patModalOpen}
         onClose={() => setPatModalOpen(false)}
+      />
+      <LearnMoreModal
+        open={open}
+        onClose={() => setOpen(false)}
       />
     </>
   )

--- a/src/components/AnalysisBanner.jsx
+++ b/src/components/AnalysisBanner.jsx
@@ -1,0 +1,214 @@
+import React, { useState } from 'react'
+import { FiLock, FiLoader, FiInfo, } from 'react-icons/fi'
+import { IoMdAnalytics } from "react-icons/io";
+import { useApp } from '../context/AppContext'
+import PATModal from './PATModal'
+
+
+export default function AnalysisBanner({ page, description, onRun, loading = false, analysisStatus = 'sample', }) {
+  const { pat } = useApp()
+  const [open, setOpen] = useState(false)
+  const [patModalOpen, setPatModalOpen] = useState(false)
+
+  if (analysisStatus === 'complete') return null
+
+  return (
+    <>
+      <div
+        style={{
+          marginBottom: 24,
+
+          background: 'var(--surface)',
+          border: '1px solid var(--accent-border)',
+          borderRadius: 'var(--radius)',
+          boxShadow: 'var(--shadow-sm)',
+
+          padding: '20px 22px',
+
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 24,
+
+          transition: 'var(--transition)',
+        }}
+      >
+        {/* Left */}
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 18,
+            flex: 1,
+          }}
+        >
+          <div
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 'var(--radius-sm)',
+
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+
+              background: 'var(--accent-soft)',
+              border: '1px solid var(--accent-border)',
+
+              color: 'var(--accent)',
+              flexShrink: 0,
+            }}
+          >
+            <IoMdAnalytics size={20} />
+
+          </div>
+
+          <div>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+
+              <span
+                style={{
+                  fontSize: 15,
+                  fontWeight: 700,
+                  color: 'var(--text)',
+                }}
+              >
+                You are viewing <span style={{ color: 'var(--accent)' }}>Sample Analysis</span>
+              </span>
+            </div>
+
+            <div
+              style={{
+                fontSize: 13,
+                color: 'var(--text2)',
+                lineHeight: 1.65,
+                maxWidth: 680,
+              }}
+            >
+              {description}
+            </div>
+          </div>
+        </div>
+
+        {/* Right */}
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            flexShrink: 0,
+          }}
+        >
+          <button
+            onClick={() => setOpen(true)}
+            style={{
+              padding: '10px 18px',
+
+              borderRadius: 'var(--radius-sm)',
+
+              background: 'transparent',
+
+              border: '1px solid var(--border)',
+
+              color: 'var(--text)',
+
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+
+              fontSize: 13,
+              fontWeight: 500,
+
+              transition: 'var(--transition)',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.background = 'var(--surface2)'
+              e.currentTarget.style.borderColor = 'var(--accent-border)'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.background = 'transparent'
+              e.currentTarget.style.borderColor = 'var(--border)'
+            }}
+          >
+            <FiInfo size={15} />
+            Learn More
+          </button>
+
+          <button
+            disabled={loading}
+            onClick={() => {
+              if (!pat) {
+                setPatModalOpen(true)
+                return
+              }
+
+              onRun()
+            }}
+            style={{
+              padding: '10px 18px',
+
+              borderRadius: 'var(--radius-sm)',
+
+              border: 'none',
+
+              background: 'var(--accent)',
+              color: '#111',
+
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+
+              fontWeight: 600,
+              fontSize: 13,
+
+              cursor: loading ? 'not-allowed' : 'pointer',
+
+              opacity: loading ? 0.65 : 1,
+
+              boxShadow: '0 4px 14px rgba(245,197,24,.18)',
+
+              transition: 'var(--transition)',
+            }}
+            onMouseEnter={e => {
+              if (!loading) {
+                e.currentTarget.style.transform = 'translateY(-1px)'
+                e.currentTarget.style.boxShadow =
+                  '0 8px 22px rgba(245,197,24,.25)'
+              }
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = 'translateY(0)'
+              e.currentTarget.style.boxShadow =
+                '0 4px 14px rgba(245,197,24,.18)'
+            }}
+          >
+            {loading ? (
+              <>
+                <FiLoader className="spin" size={15} />
+                Running...
+              </>
+            ) : (
+              <>
+                <FiLock size={14} />
+                {pat ? 'Run Complete Analysis' : 'Connect PAT & Run'}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+      <PATModal
+        open={patModalOpen}
+        onClose={() => setPatModalOpen(false)}
+      />
+    </>
+  )
+}

--- a/src/components/AnalysisBanner.jsx
+++ b/src/components/AnalysisBanner.jsx
@@ -81,7 +81,7 @@ export default function AnalysisBanner({ page, description, onRun, loading = fal
                   color: 'var(--text)',
                 }}
               >
-                You are viewing <span style={{ color: 'var(--accent)' }}>Sample Analysis</span>
+                You are viewing <span style={{ color: 'var(--accent)' }}>Standard Analysis</span>
               </span>
             </div>
 
@@ -109,6 +109,7 @@ export default function AnalysisBanner({ page, description, onRun, loading = fal
           }}
         >
           <button
+            type="button"
             onClick={() => setOpen(true)}
             style={{
               padding: '10px 18px',
@@ -144,6 +145,7 @@ export default function AnalysisBanner({ page, description, onRun, loading = fal
           </button>
 
           <button
+            type="button"
             disabled={loading}
             onClick={() => {
               if (!pat) {

--- a/src/components/LearnModeModal.jsx
+++ b/src/components/LearnModeModal.jsx
@@ -1,0 +1,279 @@
+import React from "react";
+import { FiX } from "react-icons/fi";
+
+export default function LearnMoreModal({ open, onClose }) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,.55)",
+          zIndex: 999,
+        }}
+      />
+
+      <div
+        style={{
+          position: "fixed",
+          left: "50%",
+          top: "50%",
+          transform: "translate(-50%,-50%)",
+          width: 720,
+          maxWidth: "95vw",
+          maxHeight: "85vh",
+          overflowY: "auto",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          zIndex: 1000,
+          boxShadow: "0 20px 60px rgba(0,0,0,.45)",
+        }}
+      >
+        <div
+          style={{
+            padding: "18px 24px",
+            borderBottom: "1px solid var(--border)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            position: "sticky",
+            top: 0,
+            background: "var(--surface)",
+          }}
+        >
+          <div style={{ fontSize: 18, fontWeight: 700 }}>
+            Standard vs. Complete Analysis
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              border: "none",
+              color: "var(--text2)",
+              cursor: "pointer",
+            }}
+          >
+            <FiX size={20} />
+          </button>
+        </div>
+
+        <div style={{ padding: 24 }}>
+          <div style={{ marginBottom: 28 }}>
+            <div
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--accent)",
+                marginBottom: 8,
+              }}
+            >
+              Standard Analysis
+            </div>
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--text2)",
+                lineHeight: 1.65,
+                marginBottom: 16,
+              }}
+            >
+              To keep analysis fast and avoid GitHub API limits, standard mode
+              analyzes a representative subset of the organization.
+            </div>
+
+            <div
+              style={{
+                fontSize: 12,
+                color: "var(--text2)",
+                letterSpacing: ".06em",
+                marginBottom: 10,
+              }}
+            >
+              CURRENT LIMITS
+            </div>
+
+            <div style={{ display: "grid", gap: 10 }}>
+              {[
+                ["Repositories fetched", "Up to 500 repositories"],
+                [
+                  "Repositories used for contributor and issue analysis",
+                  "Top 10 repositories ranked by a weighted score (stars + 2× forks + 1.5× watchers, with a bonus for repos pushed to within the last year)",
+                ],
+                [
+                  "Contributors",
+                  "Up to 100 contributors per repository (≈1,000 per organization)",
+                ],
+                [
+                  "Issues & Pull Requests",
+                  "Up to 100 issues/PRs per repository (≈1,000 per organization)",
+                ],
+              ].map(([label, value]) => (
+                <div
+                  key={label}
+                  style={{
+                    background: "var(--surface2)",
+                    padding: 14,
+                    borderRadius: 8,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: "var(--text)",
+                      marginBottom: 4,
+                    }}
+                  >
+                    {label}
+                  </div>
+                  <div style={{ fontSize: 13, color: "var(--text2)" }}>
+                    {value}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--text2)",
+                lineHeight: 1.65,
+                marginTop: 14,
+              }}
+            >
+              Repository rankings, contributor intelligence, governance
+              metrics, network visualization, and activity trends are all
+              calculated using this standard dataset.
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div
+            style={{
+              height: 1,
+              background: "var(--border)",
+              margin: "24px 0",
+            }}
+          />
+
+          {/* Complete Mode */}
+          <div>
+            <div
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--accent)",
+                marginBottom: 8,
+              }}
+            >
+              Complete Analysis
+            </div>
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--text2)",
+                lineHeight: 1.65,
+                marginBottom: 16,
+              }}
+            >
+              Complete Analysis uses a GitHub Personal Access Token (PAT) to
+              retrieve the full organization dataset.
+            </div>
+
+            <div
+              style={{
+                fontSize: 12,
+                color: "var(--text2)",
+                letterSpacing: ".06em",
+                marginBottom: 10,
+              }}
+            >
+              CURRENT LIMITS
+            </div>
+
+            <div style={{ display: "grid", gap: 10 }}>
+              {[
+                ["Repositories fetched", "All public repositories"],
+                ["Contributors", "Up to 1,000 contributors per repository"],
+                [
+                  "Issues & Pull Requests",
+                  "Up to 1,000 issues/PRs per repository",
+                ],
+              ].map(([label, value]) => (
+                <div
+                  key={label}
+                  style={{
+                    background: "var(--surface2)",
+                    padding: 14,
+                    borderRadius: 8,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: "var(--text)",
+                      marginBottom: 4,
+                    }}
+                  >
+                    {label}
+                  </div>
+                  <div style={{ fontSize: 13, color: "var(--text2)" }}>
+                    {value}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--text2)",
+                lineHeight: 1.65,
+                marginTop: 14,
+              }}
+            >
+              All repository rankings, contributor metrics, governance
+              insights, network visualization, and activity trends are
+              calculated using the complete dataset.
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: "16px 24px",
+            borderTop: "1px solid var(--border)",
+            display: "flex",
+            justifyContent: "flex-end",
+            position: "sticky",
+            bottom: 0,
+            background: "var(--surface)",
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "transparent",
+              color: "var(--text)",
+              cursor: "pointer",
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/PATModal.jsx
+++ b/src/components/PATModal.jsx
@@ -1,0 +1,312 @@
+import React, { useState, useEffect } from "react";
+import {FiEye, FiEyeOff, FiSave, FiTrash2, FiX} from "react-icons/fi";
+import { useApp } from "../context/AppContext";
+
+export default function PATModal({ open, onClose }) {
+  const { pat, savePat } = useApp();
+
+  const [draft, setDraft] = useState(pat);
+  const [show, setShow] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setDraft(pat);
+      setSaved(false);
+    }
+  }, [open, pat]);
+
+  if (!open) return null;
+
+  const handleSave = () => {
+    savePat(draft.trim());
+    setSaved(true);
+
+    setTimeout(() => {
+      setSaved(false);
+    }, 1500);
+  };
+
+  const handleDelete = () => {
+    savePat("");
+    setDraft("");
+  };
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,.55)",
+          zIndex: 999,
+        }}
+      />
+
+      {/* Modal */}
+      <div
+        style={{
+          position: "fixed",
+          left: "50%",
+          top: "50%",
+          transform: "translate(-50%,-50%)",
+          width: 720,
+          maxWidth: "95vw",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          zIndex: 1000,
+          boxShadow: "0 20px 60px rgba(0,0,0,.45)",
+          overflow: "hidden",
+        }}
+      >
+        {/* Header */}
+
+        <div
+          style={{
+            padding: "18px 24px",
+            borderBottom: "1px solid var(--border)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+              }}
+            >
+              GitHub Personal Access Token
+            </div>
+
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--text2)",
+                marginTop: 4,
+              }}
+            >
+              Stored locally in your browser. Never sent anywhere except GitHub.
+            </div>
+          </div>
+
+          <button
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              border: "none",
+              color: "var(--text2)",
+              cursor: "pointer",
+            }}
+          >
+            <FiX size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+
+        <div
+          style={{
+            padding: 24,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--text2)",
+              marginBottom: 6,
+              letterSpacing: ".06em",
+            }}
+          >
+            PERSONAL ACCESS TOKEN
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              marginBottom: 16,
+            }}
+          >
+            <input
+              type={show ? "text" : "password"}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="ghp_xxxxxxxxxxxxxxxxx"
+              style={{
+                flex: 1,
+                padding: "10px 12px",
+                background: "var(--surface2)",
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+                borderRadius: 8,
+              }}
+            />
+
+            <button
+              onClick={() => setShow((s) => !s)}
+              style={{
+                padding: "0 14px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "transparent",
+                color: "var(--text)",
+                cursor: "pointer",
+              }}
+            >
+              {show ? <FiEyeOff /> : <FiEye />}
+            </button>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: 10,
+              marginBottom: 30,
+            }}
+          >
+            <button
+              onClick={handleSave}
+              disabled={!draft.trim()}
+              style={{
+                padding: "10px 18px",
+                border: "none",
+                borderRadius: 8,
+                background: "var(--accent)",
+                color: "#111",
+                fontWeight: 600,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <FiSave />
+              {saved ? "Saved" : "Save"}
+            </button>
+
+            <button
+              onClick={handleDelete}
+              disabled={!draft.trim()}
+              style={{
+                padding: "10px 18px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "transparent",
+                color: "var(--text)",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <FiTrash2 />
+              Delete
+            </button>
+          </div>
+
+          <div
+            style={{
+              fontWeight: 600,
+              marginBottom: 16,
+            }}
+          >
+            How to create a PAT
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 12,
+            }}
+          >
+            {[
+              [
+                "01",
+                "Go to GitHub Settings → Developer settings → Personal access tokens",
+              ],
+              [
+                "02",
+                'Click "Generate new token" and choose Fine-grained token',
+              ],
+              [
+                "03",
+                "Give it a name and choose an expiration.",
+              ],
+              [
+                "04",
+                'Grant "Public repositories" read-only permission.',
+              ],
+              [
+                "05",
+                "Generate the token and copy it.",
+              ],
+              [
+                "06",
+                "Paste it above and click Save.",
+              ],
+            ].map(([n, text]) => (
+              <div
+                key={n}
+                style={{
+                  background: "var(--surface2)",
+                  padding: 14,
+                  borderRadius: 8,
+                }}
+              >
+                <div
+                  style={{
+                    color: "var(--accent)",
+                    fontWeight: 700,
+                    marginBottom: 6,
+                  }}
+                >
+                  {n}
+                </div>
+
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: "var(--text2)",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {text}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+
+        <div
+          style={{
+            padding: "16px 24px",
+            borderTop: "1px solid var(--border)",
+            display: "flex",
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            onClick={onClose}
+            style={{
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "transparent",
+              color: "var(--text)",
+              cursor: "pointer",
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/PATModal.jsx
+++ b/src/components/PATModal.jsx
@@ -94,6 +94,7 @@ export default function PATModal({ open, onClose }) {
           </div>
 
           <button
+            type="button"
             onClick={onClose}
             style={{
               background: "transparent",
@@ -147,6 +148,7 @@ export default function PATModal({ open, onClose }) {
             />
 
             <button
+              type="button"
               onClick={() => setShow((s) => !s)}
               style={{
                 padding: "0 14px",
@@ -169,6 +171,7 @@ export default function PATModal({ open, onClose }) {
             }}
           >
             <button
+              type="button"
               onClick={handleSave}
               disabled={!draft.trim()}
               style={{
@@ -189,6 +192,7 @@ export default function PATModal({ open, onClose }) {
             </button>
 
             <button
+              type="button"
               onClick={handleDelete}
               disabled={!draft.trim()}
               style={{
@@ -293,6 +297,7 @@ export default function PATModal({ open, onClose }) {
           }}
         >
           <button
+            type="button"
             onClick={onClose}
             style={{
               padding: "10px 20px",

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -124,14 +124,22 @@ export function AppProvider({ children }) {
     }
   }, [pat])
 
-  // Governance audit — parallel batches of 5 (Section 3.2.5)
   const runAudit = useCallback(async () => {
     if (!model || govLoading) return
     setGovLoading(true)
-    const map   = {}
-    const repos = pat? model.allRepos : model.allRepos.slice(0, 15)
+    const map = {}
 
-    // Batches of 5 using Promise.allSettled
+    // Group allRepos by org works for 1 org or many
+    const byOrg = {}
+    for (const repo of model.allRepos) {
+      (byOrg[repo.orgLogin] ??= []).push(repo)
+    }
+
+    // PAT than all repos in that org | no PAT then top 10 repos in that org
+    const repos = Object.values(byOrg).flatMap(orgRepos =>
+      pat ? orgRepos : getTopRepositories(orgRepos, 10)
+    )
+
     for (let i = 0; i < repos.length; i += 5) {
       const batch = repos.slice(i, i + 5)
       await Promise.allSettled(batch.map(async repo => {
@@ -146,7 +154,7 @@ export function AppProvider({ children }) {
     <Ctx.Provider value={{
       pat, savePat, orgs, model, issuesData,
       rateLimit, loading, loadMsg, govLoading, error, totalRepo,
-      explore, runAudit, setError,
+      explore, runAudit, setError
     }}>
       {children}
     </Ctx.Provider>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -34,6 +34,10 @@ export function AppProvider({ children }) {
   const [loadMsg, setLoadMsg] = useState('')
   const [govLoading, setGovLoading] = useState(false)
   const [error, setError] = useState('')
+  const [totalRepo, setTotalRepo] = useState(0)
+  const [isComplete, setIsComplete] = useState(false)
+  const [auditComplete, setAuditComplete] = useState(false)
+  const [lastOrgNames, setLastOrgNames] = useState([])
 
   useEffect(() => {
     const handler = e => {
@@ -58,15 +62,21 @@ export function AppProvider({ children }) {
 
     return () => clearTimeout(timeout)
   }, [rateLimit])
-  const [totalRepo, setTotalRepo] = useState(0);
+
   const savePat = useCallback(token => {
     setPat(token)
     token ? localStorage.setItem('oe_pat', token) : localStorage.removeItem('oe_pat')
   }, [])
 
-  // Multi-org explore — core of Section 3.2.0
+  // Multi-org explore
   const explore = useCallback(async orgNames => {
-    setLoading(true); setError(''); setModel(null); setOrgs([]); setIssuesData({})
+    setLoading(true);
+    setError('');
+    setModel(null);
+    setOrgs([]);
+    setIssuesData({});
+    setLastOrgNames(orgNames);
+    setAuditComplete(false);
     try {
       setLoadMsg('Fetching organization metadata...')
       const orgRes = await Promise.allSettled(orgNames.map(n => fetchOrg(n, pat)))
@@ -80,17 +90,11 @@ export function AppProvider({ children }) {
         reposPerOrg[org.login] = await fetchRepos(org.login, org.public_repos, pat)
       }))
 
-      const total = Object.values(reposPerOrg).reduce(
-        (sum, repos) => sum + repos.length,
-        0
-      );
-
+      const total = Object.values(reposPerOrg).reduce((sum, repos) => sum + repos.length, 0);
       setTotalRepo(total);
+
       const totalReposPerOrg = Object.fromEntries(
-        Object.entries(reposPerOrg).map(([org, repos]) => [
-          org,
-          [...repos], // copy each array
-        ])
+        Object.entries(reposPerOrg).map(([org, repos]) => [org, [...repos]])
       );
 
       setLoadMsg('Fetching contributor data for top repositories...')
@@ -98,7 +102,7 @@ export function AppProvider({ children }) {
       for (const org of validOrgs) {
 
         const top = pat ? (reposPerOrg[org.login] || []) : getTopRepositories(reposPerOrg[org.login] || [], 10);
-        reposPerOrg[org.login] = top; // Update to only include top repos
+        reposPerOrg[org.login] = top;
 
         await Promise.allSettled(top.map(async repo => {
           contribsPerRepo[`${org.login}/${repo.name}`] = await fetchContributors(org.login, repo.name, pat)
@@ -106,14 +110,16 @@ export function AppProvider({ children }) {
       }
 
       setLoadMsg('Building analytical data model...')
-      setModel(buildAnalyticalModel(validOrgs, reposPerOrg, contribsPerRepo, totalReposPerOrg))
+      const builtModel = buildAnalyticalModel(validOrgs, reposPerOrg, contribsPerRepo, totalReposPerOrg)
+      setModel(builtModel)
 
+      setIsComplete(!!pat)
 
       // Save to recent searches
       const prev = JSON.parse(localStorage.getItem('oe_recent') || '[]')
       const entry = orgNames.join(', ')
       localStorage.setItem('oe_recent', JSON.stringify([...new Set([entry, ...prev])].slice(0, 6)))
-      return true
+      return builtModel
     } catch (err) {
       setError(err.message === 'RATE_LIMIT'
         ? 'GitHub API rate limit reached. Add a PAT in Settings for 5,000 req/hr.'
@@ -124,37 +130,75 @@ export function AppProvider({ children }) {
     }
   }, [pat])
 
-  const runAudit = useCallback(async () => {
-    if (!model || govLoading) return
-    setGovLoading(true)
-    const map = {}
+  // re-run explore for the same orgs: used by the banner on
+  // Overview / Contributors / Repositories / Network
+  const runFullExplore = useCallback(() => {
+    if (!lastOrgNames.length) return Promise.resolve(false)
+    return explore(lastOrgNames)
+  }, [explore, lastOrgNames])
 
-    // Group allRepos by org works for 1 org or many
+  // Shared issue-fetch logic: same repo-selection rule as contributors
+  const auditRepos = useCallback(async (allRepos) => {
     const byOrg = {}
-    for (const repo of model.allRepos) {
+    for (const repo of allRepos) {
       (byOrg[repo.orgLogin] ??= []).push(repo)
     }
-
-    // PAT than all repos in that org | no PAT then top 10 repos in that org
     const repos = Object.values(byOrg).flatMap(orgRepos =>
       pat ? orgRepos : getTopRepositories(orgRepos, 10)
     )
 
+    const map = {}
     for (let i = 0; i < repos.length; i += 5) {
       const batch = repos.slice(i, i + 5)
       await Promise.allSettled(batch.map(async repo => {
         map[`${repo.orgLogin}/${repo.name}`] = await fetchIssues(repo.orgLogin, repo.name, pat)
       }))
     }
+    return map
+  }, [pat])
+
+  // Governance audit : used directly when repos are already complete
+  const runAudit = useCallback(async () => {
+    if (!model || govLoading) return
+    setGovLoading(true)
+    const map = await auditRepos(model.allRepos)
     setIssuesData(map)
     setGovLoading(false)
-  }, [model, pat, govLoading])
+    setAuditComplete(!!pat)
+  }, [model, pat, govLoading, auditRepos])
+
+  // Entry point for Governance / Analytics "Run Complete Analysis"
+  // - If repos/contributors aren't complete yet -> fetch them first (explore),
+  //   then fetch issues using the freshly-returned model (avoids stale closure).
+  // - If already complete -> skip repo fetching (cache/state already has it),
+  //   just fetch issues.
+  const runGovernanceAnalysis = useCallback(async () => {
+    if (govLoading) return
+
+    let currentModel = model
+    if (!isComplete) {
+      setGovLoading(true) // reflect "working" immediately, explore() also sets its own loading
+      const freshModel = await runFullExplore()
+      setGovLoading(false)
+      if (!freshModel) return
+      currentModel = freshModel
+    }
+
+    if (!currentModel) return
+
+    setGovLoading(true)
+    const map = await auditRepos(currentModel.allRepos)
+    setIssuesData(map)
+    setGovLoading(false)
+    setAuditComplete(!!pat)
+  }, [isComplete, model, runFullExplore, auditRepos, pat, govLoading])
 
   return (
     <Ctx.Provider value={{
       pat, savePat, orgs, model, issuesData,
       rateLimit, loading, loadMsg, govLoading, error, totalRepo,
-      explore, runAudit, setError
+      isComplete, auditComplete, lastOrgNames,
+      explore, runFullExplore, runAudit, runGovernanceAnalysis, setError,
     }}>
       {children}
     </Ctx.Provider>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -240,7 +240,7 @@ export function AppProvider({ children }) {
       pat, savePat, orgs, model, issuesData,
       rateLimit, loading, loadMsg, govLoading, error, totalRepo,
       isComplete, auditComplete, lastOrgNames,
-      explore, runFullExplore, runAudit, runGovernanceAnalysis, setError,
+      explore, runFullExplore, runAudit, runGovernanceAnalysis, setError, staleRepoStats
     }}>
       {children}
     </Ctx.Provider>

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -7,6 +7,7 @@ import { FiDownload, FiRefreshCw } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, PageTitle, InfoBox } from '../components/UI'
 import { buildTimeSeries, exportTrendsCSV } from '../services/analytics'
+import AnalysisBanner from '../components/AnalysisBanner'
 
 const TOOLTIP_STYLE = {
   contentStyle: {
@@ -20,7 +21,7 @@ const TOOLTIP_STYLE = {
 }
 
 export default function AnalyticsPage() {
-  const { model, issuesData, runAudit, govLoading } = useApp()
+  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis } = useApp()
   const [granularity,   setGranularity]   = useState('monthly')
   const [selectedRepo,  setSelectedRepo]  = useState('All')
 
@@ -49,6 +50,13 @@ export default function AnalyticsPage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+      <AnalysisBanner
+        page="governance"
+        description="Activity trends are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={auditComplete ? 'complete' : 'sample'}
+        loading={loading || govLoading}
+        onRun={runGovernanceAnalysis}
+      />
       <PageTitle
         title="Activity Trends"
         subtitle="How PR and issue velocity is evolving over time — created, merged, and closed per week or month"

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -7,9 +7,10 @@ import { computeBusFactor, exportContributorsCSV } from '../services/analytics'
 import { useNavigate } from 'react-router-dom'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { AiOutlineInfoCircle } from "react-icons/ai";
+import AnalysisBanner from '../components/AnalysisBanner'
 
 export default function ContributorsPage() {
-  const { model } = useApp()
+  const { model, isComplete, loading, runFullExplore } = useApp()
   const [search, setSearch] = useState('')
   const [shown, setShown] = useState(20)
   const [openInfo, setOpenInfo] = useState(null)
@@ -67,6 +68,15 @@ export default function ContributorsPage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+
+      <AnalysisBanner
+        page="contributors"
+        description="Contributor insights are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={isComplete ? 'complete' : 'standard'}
+        loading={loading}
+        onRun={runFullExplore}
+      />
+
       <PageTitle
         title="Contributor Intelligence"
         subtitle="Analyzing contribution patterns, coverage risk, and organizational health"
@@ -92,8 +102,8 @@ export default function ContributorsPage() {
             <p>Bus Factor Risk</p>
 
             <button
-              onMouseEnter={()=>setOpenInfo("busfactor")}
-              onMouseLeave={()=>setOpenInfo(null)}
+              onMouseEnter={() => setOpenInfo("busfactor")}
+              onMouseLeave={() => setOpenInfo(null)}
               className="p-2 rounded-full hover:bg-(--bg) transition"
             >
               <AiOutlineInfoCircle className="text-(--text) cursor-pointer" />
@@ -153,8 +163,8 @@ export default function ContributorsPage() {
             <p>Freshness Index</p>
 
             <button
-              onMouseEnter={()=>setOpenInfo("freshness")}
-              onMouseLeave={()=>setOpenInfo(null)}
+              onMouseEnter={() => setOpenInfo("freshness")}
+              onMouseLeave={() => setOpenInfo(null)}
               className="p-2 rounded-full hover:bg-(--bg) transition"
             >
               <AiOutlineInfoCircle className="text-(--text) cursor-pointer" />
@@ -258,8 +268,8 @@ export default function ContributorsPage() {
                       <p>SIGNALS</p>
 
                       <button
-                        onMouseEnter={()=>setOpenInfo("signals")}
-                        onMouseLeave={()=>setOpenInfo(null)}
+                        onMouseEnter={() => setOpenInfo("signals")}
+                        onMouseLeave={() => setOpenInfo(null)}
                         className="p-2 rounded-full hover:bg-(--bg) transition"
                       >
                         <AiOutlineInfoCircle className="text-(--text) cursor-pointer" />
@@ -317,10 +327,10 @@ export default function ContributorsPage() {
                           color: 'inherit',
                         }}
                       >
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <img src={c.avatar_url} alt={c.login} style={{ width: 28, height: 28, borderRadius: '50%' }} />
-                        <span style={{ fontSize: 13, fontWeight: 500 }}>{c.login}</span>
-                      </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <img src={c.avatar_url} alt={c.login} style={{ width: 28, height: 28, borderRadius: '50%' }} />
+                          <span style={{ fontSize: 13, fontWeight: 500 }}>{c.login}</span>
+                        </div>
                       </a>
                     </td>
                     <td style={{ padding: '10px 14px' }}>

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -41,7 +41,7 @@ const getStatus = ratio => {
 }
 
 export default function GovernancePage() {
-  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis } = useApp()
+  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis,staleRepoStats } = useApp()
   const [tab, setTab] = useState('dead')
 
   const ITEMS_PER_PAGE = 10

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react'
 import { FiRefreshCw, FiExternalLink } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, PageTitle, EmptyOk } from '../components/UI'
+import AnalysisBanner from '../components/AnalysisBanner'
 
 const TABS = [
   { key: 'dead',    label: 'Dead Issues' },
@@ -11,7 +12,7 @@ const TABS = [
 ]
 
 export default function GovernancePage() {
-  const { model, issuesData, runAudit, govLoading } = useApp()
+  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis } = useApp()
   const [tab, setTab] = useState('dead')
 
   // Flatten all issues and tag with repo/org
@@ -104,6 +105,13 @@ export default function GovernancePage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+      <AnalysisBanner
+        page="governance"
+        description="Governance insights are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={auditComplete ? 'complete' : 'standard'}
+        loading={loading || govLoading}
+        onRun={runGovernanceAnalysis}
+      />
       <PageTitle
         title="Governance Audit"
         subtitle="Analyzing structural integrity and compliance across the portfolio"

--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -5,9 +5,10 @@ import { C, PageTitle } from '../components/UI'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { FiDatabase } from 'react-icons/fi'
 import { useNavigate } from 'react-router-dom'
+import AnalysisBanner from '../components/AnalysisBanner'
 
 export default function NetworkPage() {
-  const { model } = useApp()
+  const { model, isComplete, loading, runFullExplore } = useApp()
   const svgRef   = useRef(null)
   const simRef   = useRef(null)
   const [tooltip,      setTooltip]      = useState(null)
@@ -156,6 +157,13 @@ export default function NetworkPage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+      <AnalysisBanner
+          page="network"
+          description="Network relationships are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+          analysisStatus={isComplete ? 'complete' : 'standard'}
+          loading={loading}
+          onRun={runFullExplore}
+      />
       <PageTitle
         title="Contributor-Repository Network"
         subtitle="Visual map of how contributors connect across repositories. Edge thickness = contribution volume. Position encodes recency — recently active nodes rise to the top."

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -5,13 +5,14 @@ import { useApp } from '../context/AppContext'
 import { C, StatCard, HealthBar } from '../components/UI'
 import SocialShareButton from '../components/SocialShareButton';
 import { AiOutlineInfoCircle } from "react-icons/ai";
+import AnalysisBanner from '../components/AnalysisBanner'
 
 
 const LANG_COLORS = ['#22c55e', '#f5c518', '#3b82f6', '#ef4444', '#a855f7', '#f97316', '#06b6d4']
 const fmt = n => n > 999 ? (n / 1000).toFixed(1) + 'k' : String(n)
 
 export default function OverviewPage() {
-  const { orgs, model, totalRepo } = useApp()
+  const { orgs, model, totalRepo, isComplete, loading, runFullExplore } = useApp()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const infoRef = useRef(null)
@@ -60,6 +61,14 @@ export default function OverviewPage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+
+      <AnalysisBanner
+        page="overview"
+        description="Organization insights are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={isComplete ? 'complete' : 'standard'}
+        loading={loading}
+        onRun={runFullExplore}
+      />
 
       {/* Org identity bar */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 28 }}>

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -7,12 +7,13 @@ import { useSortedData } from '../hooks/useSortedData'
 import { exportReposCSV } from '../services/analytics'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { useNavigate } from 'react-router-dom'
+import AnalysisBanner from '../components/AnalysisBanner'
 
 const ACTIVITY_CLASSIFICATIONS = ['All', 'Thriving', 'Active', 'Dormant', 'Hibernating']
 const ACTIVITY_COLORS = { Thriving: 'var(--green)', Active: 'var(--blue)', Dormant: 'var(--amber)', Hibernating: 'var(--red)' }
 
 export default function RepositoriesPage() {
-  const { model } = useApp()
+  const { model, isComplete, loading, runFullExplore } = useApp()
   const [search, setSearch] = useState('')
   const [activityClassification, setActivityClassification] = useState('All')
   const [lang, setLang] = useState('All Languages')
@@ -65,6 +66,13 @@ export default function RepositoriesPage() {
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
+      <AnalysisBanner
+        page="repositories"
+        description="Repository insights are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={isComplete ? 'complete' : 'standard'}
+        loading={loading}
+        onRun={runFullExplore}
+      />
       <div style={{ position: 'relative' }} ref={infoRef}>
         <PageTitle
           title={
@@ -72,8 +80,8 @@ export default function RepositoriesPage() {
               Repository Explorer
 
               <button
-                onMouseEnter={()=>setOpenInfo(true)}
-                onMouseLeave={()=>setOpenInfo(false)}
+                onMouseEnter={() => setOpenInfo(true)}
+                onMouseLeave={() => setOpenInfo(false)}
                 className="p-3 rounded-full hover:bg-(--bg) transition"
               >
                 <AiOutlineInfoCircle className="text-(--text) cursor-pointer" />
@@ -182,18 +190,18 @@ export default function RepositoriesPage() {
       {allRepos?.length ? (
         <>
           {/* Table view */}
-            <div style={{ ...C.card, padding: 0, overflowX: 'auto' }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                <thead>
-                  <tr>
-                    {TABLE_COLS.map(([k, l]) => (
-                      <SortTh key={k} label={l} sortKey={k} sortConfig={sortConfig} onSort={onSort} />
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {visible.map((r, i) => (
-                    <tr key={r.id} style={{ borderBottom: '1px solid var(--border)', background: i % 2 ? 'var(--surface2)' : 'transparent' }}>
+          <div style={{ ...C.card, padding: 0, overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  {TABLE_COLS.map(([k, l]) => (
+                    <SortTh key={k} label={l} sortKey={k} sortConfig={sortConfig} onSort={onSort} />
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((r, i) => (
+                  <tr key={r.id} style={{ borderBottom: '1px solid var(--border)', background: i % 2 ? 'var(--surface2)' : 'transparent' }}>
                     <td style={{ padding: '10px 14px' }}>
                       <a
                         href={`${r.html_url}`}
@@ -208,23 +216,23 @@ export default function RepositoriesPage() {
                         {r.orgLogin && <div style={{ fontSize: 11, color: 'var(--text2)' }}>{r.orgLogin}</div>}
                       </a>
                     </td>
-                      <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.stargazers_count.toLocaleString()}</td>
-                      <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.forks_count.toLocaleString()}</td>
-                      <td style={{ padding: '10px 14px', fontSize: 13, color: r.open_issues_count > 30 ? 'var(--red)' : 'var(--text2)' }}>{r.open_issues_count}</td>
-                      <td style={{ padding: '10px 14px', minWidth: 130 }}><HealthBar score={r.healthScore} /></td>
-                      <td style={{ padding: '10px 14px' }}>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}><Badge text={r.activityClassification} />
-                          <span style={{ fontSize: 11, color: 'var(--text2)' }}>
-                            Last push: {r.pushed_at?.slice(0, 10)}
-                          </span>
-                        </div>
-                      </td>
-                    </tr> 
-                  ))}
-                </tbody>
-              </table>
-              <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} />
-            </div>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.stargazers_count.toLocaleString()}</td>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.forks_count.toLocaleString()}</td>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: r.open_issues_count > 30 ? 'var(--red)' : 'var(--text2)' }}>{r.open_issues_count}</td>
+                    <td style={{ padding: '10px 14px', minWidth: 130 }}><HealthBar score={r.healthScore} /></td>
+                    <td style={{ padding: '10px 14px' }}>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}><Badge text={r.activityClassification} />
+                        <span style={{ fontSize: 11, color: 'var(--text2)' }}>
+                          Last push: {r.pushed_at?.slice(0, 10)}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} />
+          </div>
         </>)
         : (
           <div

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -100,7 +100,8 @@ export async function fetchRepos(org, repoCount, pat) {
 
 export async function fetchContributors(org, repo, pat) {
   const all = []
-  for(let page = 1; ; page++) {
+  const maxPages = pat ? 10 : 1
+  for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/contributors?per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
     all.push(...data)
@@ -111,7 +112,8 @@ export async function fetchContributors(org, repo, pat) {
 
 export async function fetchIssues(org, repo, pat) {
   const all = []
-  for(let page = 1; ; page++) {
+  const maxPages = pat ? 10 : 1
+  for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/issues?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
     all.push(...data)


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #


###  Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
Before
https://github.com/user-attachments/assets/749a9bf9-d5d8-4c01-96bd-ae2895d39615

After

https://github.com/user-attachments/assets/d94100f4-28eb-42f7-8e1d-a9275c178b58
https://github.com/user-attachments/assets/359bdfa7-4446-4e06-8e2f-33f8dbfd98c2
<img width="1918" height="862" alt="image" src="https://github.com/user-attachments/assets/7cbca8f0-77cb-4722-b2c3-ce2f0ba45ade" />




###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
- Added isComplete (org + all repos + all contributors fetched) and auditComplete (issues fetched for all repos) flags in AppContext to gate AnalysisBanner visibility.
- isComplete shared across Overview, Contributors, Repositories, Network — one explore() call hides the banner on all four.
- auditComplete used by Governance, Analytics — hides banner once issues are fetched for all repos.
- runGovernanceAnalysis uses the model returned by runFullExplore() directly, not context state, to avoid a stale-closure bug from async state updates.
- Skips repo/contributor refetch if isComplete is already true — goes straight to issue fetching (repo data also cached in IndexedDB regardless).
- Added lastOrgNames so any banner can re-trigger a full explore() without re-entering org names.
- Issue fetching (auditRepos) reuses the same PAT-aware repo selection as contributors (top 10/org without PAT, all repos/org with PAT) for consistency.
-  Added `LearnMoreModal.jsx` explaining Sample vs Complete Analysis limits (repos, contributors, issues/PRs, and top-repo ranking formula)
- Wired the modal into `AnalysisBanner`'s existing "Learn More" button.

### Data Fetching Caps: PAT vs No PAT
| Metric | No PAT (per org) | With PAT (per org) |
|---|---|---|
| Repos fetched | ≤500 | all (`public_repos` count) |
| Repos used for contributors/issues | 10 (top by ranking) | all fetched repos |
| Contributors | ≤100/repo × 10 repos = ≤1,000/org | ≤1000/repo × all repos |
| Issues | ≤100/repo × 10 repos = ≤1,000/org | ≤1000/repo × all repos |


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a reusable analysis banner across key pages to show analysis status, include “Learn more,” and provide a clear “Run” action.
  * Added a personal access token dialog for connecting/editing a token directly from the UI.
  * Expanded analysis workflows so pages can trigger full exploration and governance/audit updates.

* **Bug Fixes**
  * Improved contributor and issue fetching by switching to predictable, bounded pagination.
  * Refined repository/contributor page layouts while keeping displayed information the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->