### PR TITLE
Add loading skeletons across pages

### DIFF
--- a/src/components/Orgexplorerskeletons.jsx
+++ b/src/components/Orgexplorerskeletons.jsx
@@ -1,0 +1,313 @@
+import React, { useState } from "react";
+
+const Bar = ({ w = "100%", h = "0.75rem", className = "" }) => (
+  <div
+    className={`animate-pulse rounded bg-neutral-800 ${className}`}
+    style={{ width: w, height: h }}
+  />
+);
+
+const Box = ({ className = "", children }) => (
+  <div
+    className={`rounded-lg border border-neutral-800 bg-neutral-900 p-4 ${className}`}
+  >
+    {children}
+  </div>
+);
+
+const Circle = ({ size = 40 }) => (
+  <div
+    className="animate-pulse rounded-full bg-neutral-800 shrink-0"
+    style={{ width: size, height: size }}
+  />
+);
+
+const Pill = ({ w = "4rem" }) => (
+  <div className="animate-pulse rounded-full bg-neutral-800 h-5" style={{ width: w }} />
+);
+
+/* Overview */
+export function OverviewSkeleton() {
+  return (
+    <div className="min-h-screen p-6 space-y-6 w-295 mx-auto">
+      {/* header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Circle size={40} />
+          <div className="space-y-2">
+            <Bar w="140px" h="1rem" />
+            <Bar w="240px" h="0.65rem" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Bar w="110px" h="2.25rem" className="rounded-md" />
+          <Bar w="80px" h="2.25rem" className="rounded-md" />
+        </div>
+      </div>
+
+      {/* stat cards */}
+      <div className="grid grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Box key={i} className="space-y-3">
+            <Bar w="70%" h="0.6rem" />
+            <Bar w="40%" h="1.5rem" />
+          </Box>
+        ))}
+      </div>
+
+      {/* language distribution + high impact repos */}
+      <div className="grid grid-cols-2 gap-4">
+        <Box className="space-y-4">
+          <Bar w="55%" h="0.9rem" />
+          <Bar w="35%" h="0.6rem" />
+          <Bar w="100%" h="0.9rem" className="rounded-full" />
+          <div className="flex gap-4 flex-wrap">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Pill key={i} w="60px" />
+            ))}
+          </div>
+        </Box>
+        <Box className="space-y-4">
+          <Bar w="45%" h="0.9rem" />
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Bar w="30%" h="0.7rem" />
+              <div className="flex items-center gap-2">
+                <Bar w="80%" h="0.5rem" className="rounded-full" />
+                <Bar w="24px" h="0.7rem" />
+              </div>
+            </div>
+          ))}
+        </Box>
+      </div>
+
+      {/* nav cards */}
+      <div className="grid grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Box key={i} className="space-y-2">
+            <Bar w="50%" h="0.9rem" />
+            <Bar w="90%" h="0.6rem" />
+            <Bar w="90%" h="0.6rem" />
+            <Bar w="35%" h="0.6rem" />
+          </Box>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* Repository Explorer */
+export function RepositorySkeleton() {
+  return (
+    <div className="min-h-screen w-295 p-6 space-y-6 mx-auto">
+      <div className="flex items-center justify-between">
+        <Bar w="200px" h="1.25rem" />
+        <Bar w="70px" h="1.25rem" />
+      </div>
+
+      <div className="flex gap-3">
+        <Bar w="100%" h="2.25rem" className="rounded-md flex-1" />
+        <Bar w="140px" h="2.25rem" className="rounded-md" />
+        <Bar w="90px" h="2.25rem" className="rounded-md" />
+      </div>
+
+      <div className="flex gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Bar key={i} w="90px" h="2rem" className="rounded-md" />
+        ))}
+      </div>
+
+      <Box className="divide-y divide-neutral-800 p-0">
+        {Array.from({ length: 15 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between px-4 py-3">
+            <div className="space-y-2 w-1/4">
+              <Bar w="70%" h="0.8rem" />
+              <Bar w="40%" h="0.55rem" />
+            </div>
+            <Bar w="40px" h="0.7rem" />
+            <Bar w="40px" h="0.7rem" />
+            <Bar w="40px" h="0.7rem" />
+            <Bar w="120px" h="0.5rem" className="rounded-full" />
+            <Bar w="80px" h="1.4rem" className="rounded-full" />
+          </div>
+        ))}
+      </Box>
+    </div>
+  );
+}
+
+/* Contributor Intelligence */
+export function ContributorSkeleton() {
+  return (
+    <div className="min-h-screen w-295 p-6 space-y-6 mx-auto">
+      <div className="space-y-2">
+        <Bar w="280px" h="1.25rem" />
+        <Bar w="420px" h="0.65rem" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Box className="space-y-3">
+          <Bar w="35%" h="0.6rem" />
+          <Bar w="45%" h="1.5rem" />
+          <Bar w="100%" h="0.5rem" className="rounded-full" />
+        </Box>
+        <Box className="space-y-3">
+          <Bar w="35%" h="0.6rem" />
+          <div className="flex items-center gap-3">
+            <Circle size={56} />
+            <div className="space-y-2 flex-1">
+              <Bar w="60%" h="0.7rem" />
+              <Bar w="80%" h="0.55rem" />
+            </div>
+          </div>
+        </Box>
+      </div>
+
+      <Bar w="160px" h="2.25rem" className="rounded-md" />
+
+      <Box className="divide-y divide-neutral-800 p-0">
+        {Array.from({ length: 15 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between px-4 py-3">
+            <div className="flex items-center gap-3 w-1/4">
+              <Circle size={28} />
+              <Bar w="70%" h="0.75rem" />
+            </div>
+            <Bar w="60px" h="0.7rem" />
+            <Bar w="30px" h="0.7rem" />
+            <Bar w="20px" h="0.7rem" />
+            <Bar w="70px" h="0.7rem" />
+            <Bar w="60px" h="1.3rem" className="rounded-full" />
+          </div>
+        ))}
+      </Box>
+    </div>
+  );
+}
+
+/* Contributor-Repository Network */
+export function NetworkSkeleton() {
+  const nodes = Array.from({ length: 26 }).map(() => ({
+    x: 8 + Math.random() * 84,
+    y: 10 + Math.random() * 75,
+    size: 8 + Math.random() * 10,
+  }));
+
+  return (
+    <div className="min-h-screen w-295 p-6 space-y-4 mx-auto">
+      <div className="space-y-2">
+        <Bar w="320px" h="1.25rem" />
+        <Bar w="480px" h="0.65rem" />
+      </div>
+
+      <div className="flex gap-2">
+        <Bar w="100px" h="2rem" className="rounded-md" />
+        <Bar w="100px" h="2rem" className="rounded-md" />
+      </div>
+
+      <Bar w="380px" h="0.6rem" />
+
+      <div className="relative h-96 rounded-lg border border-neutral-800 bg-neutral-950 overflow-hidden">
+        {nodes.map((n, i) => (
+          <div
+            key={i}
+            className="absolute animate-pulse rounded-full bg-neutral-800"
+            style={{
+              left: `${n.x}%`,
+              top: `${n.y}%`,
+              width: n.size,
+              height: n.size,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* Analytics */
+export function AnalyticsSkeleton() {
+  return (
+    <div className="min-h-screen w-295 p-6 space-y-8 mx-auto">
+      <div className="space-y-2">
+        <Bar w="180px" h="1.25rem" />
+        <Bar w="380px" h="0.65rem" />
+      </div>
+
+      <div className="flex gap-3">
+        <Bar w="120px" h="2.25rem" className="rounded-md" />
+        <Bar w="100px" h="2.25rem" className="rounded-md" />
+        <Bar w="100px" h="2.25rem" className="rounded-md" />
+        <Bar w="180px" h="2.25rem" className="rounded-md" />
+      </div>
+
+      <Box className="h-56 flex items-center justify-center">
+        <Bar w="220px" h="0.8rem" />
+      </Box>
+
+      <div className="space-y-2">
+        <Bar w="220px" h="1.1rem" />
+        <Bar w="400px" h="0.6rem" />
+      </div>
+
+      <div className="flex gap-3">
+        <Bar w="160px" h="2.25rem" className="rounded-md" />
+        <Bar w="200px" h="2.25rem" className="rounded-md" />
+      </div>
+
+      <Box className="h-56 flex items-center justify-center">
+        <Bar w="220px" h="0.8rem" />
+      </Box>
+    </div>
+  );
+}
+
+/* Governance Audit */
+export function GovernanceSkeleton() {
+  return (
+    <div className="min-h-screen w-295 p-6 space-y-6 mx-auto">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Bar w="220px" h="1.25rem" />
+          <Bar w="360px" h="0.65rem" />
+        </div>
+        <Bar w="120px" h="2.25rem" className="rounded-md" />
+      </div>
+
+      <div className="grid grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Box key={i} className="space-y-3">
+            <Bar w="70%" h="0.6rem" />
+            <Bar w="40%" h="1.5rem" />
+            <Bar w="50%" h="0.55rem" />
+          </Box>
+        ))}
+      </div>
+
+      <Box className="space-y-4">
+        <Bar w="220px" h="0.9rem" />
+        <Bar w="320px" h="0.6rem" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Bar w="120px" h="0.7rem" />
+              <Bar w="70px" h="0.55rem" />
+            </div>
+            <Bar w="70px" h="0.6rem" />
+          </div>
+        ))}
+      </Box>
+
+      <div className="flex gap-6 border-b border-neutral-800 pb-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Bar key={i} w="90px" h="0.75rem" />
+        ))}
+      </div>
+
+      <Box className="h-40 flex flex-col items-center justify-center gap-2">
+        <Bar w="180px" h="0.8rem" />
+        <Bar w="240px" h="0.6rem" />
+      </Box>
+    </div>
+  );
+}
+

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -9,6 +9,7 @@ import { IoChevronDown } from 'react-icons/io5'
 import { HiCheck, HiOutlineClock } from 'react-icons/hi'
 import { useAdvancedMetrics } from '../hooks/useSortedData'
 import AnalysisBanner from '../components/AnalysisBanner'
+import { AnalyticsSkeleton } from '../components/Orgexplorerskeletons'
 
 const TOOLTIP_STYLE = {
   contentStyle: {
@@ -51,6 +52,7 @@ export default function AnalyticsPage() {
     return key ? (pullsData[key] || []) : []
   }, [pullsData, selectedRepoForAM])
 
+  if(loading) return <AnalyticsSkeleton />
   if (!model) return null
 
   const advancedMetrics = useAdvancedMetrics(filteredPulls)
@@ -168,7 +170,7 @@ export default function AnalyticsPage() {
       {govLoading && (
         <InfoBox>
           <div style={{ fontSize: 14, color: 'var(--text)' }}>
-            Fetching issue and PR history for top 15 repositories in batches of 5...
+            Fetching issue and PR history for top 10 repositories in batches of 5...
           </div>
         </InfoBox>
       )}

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import AnalysisBanner from '../components/AnalysisBanner'
+import { ContributorSkeleton } from '../components/Orgexplorerskeletons'
 
 export default function ContributorsPage() {
   const { model, isComplete, loading, runFullExplore } = useApp()
@@ -56,6 +57,7 @@ export default function ContributorsPage() {
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'totalContribs', 'desc')
   const visible = sorted.slice(0, shown)
 
+  if(loading) return <ContributorSkeleton />
   if (!model) return null
 
   const topActive = contributors.slice(0, 10).filter(c => c.freshness > 50).length

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -3,6 +3,7 @@ import { FiRefreshCw, FiExternalLink } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, PageTitle, EmptyOk } from '../components/UI'
 import AnalysisBanner from '../components/AnalysisBanner'
+import { GovernanceSkeleton } from '../components/Orgexplorerskeletons'
 
 const TABS = [
   { key: 'dead',    label: 'Dead Issues' },
@@ -63,6 +64,7 @@ export default function GovernancePage() {
     return arr
   }, [issuesData])
 
+  if(loading) return <GovernanceSkeleton />
   if (!model) return null
 
   const hasAudit = Object.keys(issuesData || {}).length > 0

--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -6,6 +6,7 @@ import EmptyStateCard from '../components/EmptyStateCard'
 import { FiDatabase } from 'react-icons/fi'
 import { useNavigate } from 'react-router-dom'
 import AnalysisBanner from '../components/AnalysisBanner'
+import { NetworkSkeleton } from '../components/Orgexplorerskeletons'
 
 export default function NetworkPage() {
   const { model, isComplete, loading, runFullExplore } = useApp()
@@ -154,7 +155,8 @@ export default function NetworkPage() {
   }, [model, showRepos, showContribs])
 
   const navigate = useNavigate()
-
+  if(loading) return <NetworkSkeleton />
+  
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
       <AnalysisBanner

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -6,7 +6,7 @@ import { C, StatCard, HealthBar } from '../components/UI'
 import SocialShareButton from '../components/SocialShareButton';
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import AnalysisBanner from '../components/AnalysisBanner'
-
+import { OverviewSkeleton } from '../components/Orgexplorerskeletons'
 
 const LANG_COLORS = ['#22c55e', '#f5c518', '#3b82f6', '#ef4444', '#a855f7', '#f97316', '#06b6d4']
 const fmt = n => n > 999 ? (n / 1000).toFixed(1) + 'k' : String(n)
@@ -29,6 +29,7 @@ export default function OverviewPage() {
     }
   }, [])
 
+  if(loading) return <OverviewSkeleton />
   if (!model) return null
 
   const { totalRepos } = model

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -8,6 +8,7 @@ import { exportReposCSV } from '../services/analytics'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { useNavigate } from 'react-router-dom'
 import AnalysisBanner from '../components/AnalysisBanner'
+import { RepositorySkeleton } from '../components/Orgexplorerskeletons';
 
 const ACTIVITY_CLASSIFICATIONS = ['All', 'Thriving', 'Active', 'Dormant', 'Hibernating']
 const ACTIVITY_COLORS = { Thriving: 'var(--green)', Active: 'var(--blue)', Dormant: 'var(--amber)', Hibernating: 'var(--red)' }
@@ -53,6 +54,7 @@ export default function RepositoriesPage() {
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'healthScore', 'desc')
   const visible = sorted.slice(0, shown)
 
+  if(loading) return <RepositorySkeleton />
   if (!model) return null
 
   const TABLE_COLS = [


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #
Currently these pages show a blank screen / generic spinner while data loads (repo list, contributor stats, network graph, etc). On slower connections this blank gap can last long enough that it looks like the app has crashed or frozen, rather than just loading. Layout-matched skeletons reduce that perceived load time and avoid layout shift once real data arrives.

###  Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
Before
<img width="1918" height="852" alt="Screenshot 2026-07-09 002305" src="https://github.com/user-attachments/assets/e994d24d-9f40-41e5-a8b3-806789a664a7" />

Video: 

https://github.com/user-attachments/assets/16cc1736-2da7-4611-ae33-89653f8c9ccc

After: 
<img width="1883" height="848" alt="Screenshot 2026-07-09 002344" src="https://github.com/user-attachments/assets/dd961ed2-2010-44e4-8230-e20bf6d31be6" />

Video:

https://github.com/user-attachments/assets/49e456b7-a1ca-41fd-8ec2-f480395982b0


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
## Changes
- `OverviewSkeleton` — header, 4 stat cards, language distribution + high-impact repos, 6 nav cards
- `RepositorySkeleton` — banner, search/filter row, tab pills, table rows
- `ContributorSkeleton` — bus factor + freshness cards, contributor table
- `NetworkSkeleton` — toggle controls + scattered pulsing nodes
- `AnalyticsSkeleton` — filter row, chart placeholder, advanced analytics controls
- `GovernanceSkeleton` — stat cards, resolution list, tab bar, status panel
- Shared primitives (`Bar`, `Box`, `Circle`, `Pill`) built on Tailwind's `animate-pulse`, no extra CSS needed

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated loading skeleton screens for Overview, Repositories, Contributors, Network, Analytics, and Governance pages.
  * Network loading now shows a visual placeholder with animated pulsing nodes.
* **Bug Fixes**
  * Pages now switch immediately to placeholder content while data is loading, preventing partial/blank rendering.
  * Improved loading behavior on the Analytics page by rendering the skeleton UI during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->