### PR TITLE
Fix PR-metrics scoping and align UI consistency in Analytics page

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -37,6 +37,7 @@ export function AppProvider({ children }) {
   const [error, setError] = useState('')
   const [totalRepo, setTotalRepo] = useState(0)
   const [advanceAnalyticsLoading, setAdvanceAnalyticsLoading] = useState(false);
+  const [advanceAnalyticsComplete, setAdvanceAnalyticsComplete] = useState(false) 
   const [isComplete, setIsComplete] = useState(false)
   const [auditComplete, setAuditComplete] = useState(false)
   const [lastOrgNames, setLastOrgNames] = useState([])
@@ -87,6 +88,7 @@ export function AppProvider({ children }) {
     setIssuesData({});
     setLastOrgNames(orgNames);
     setAuditComplete(false);
+    setAdvanceAnalyticsComplete(false);
     try {
       setLoadMsg('Fetching organization metadata...')
       const orgRes = await Promise.allSettled(orgNames.map(n => fetchOrg(n, pat)))
@@ -147,15 +149,19 @@ export function AppProvider({ children }) {
     return explore(lastOrgNames)
   }, [explore, lastOrgNames])
 
-  // Shared issue-fetch logic: same repo-selection rule as contributors
-  const auditRepos = useCallback(async (allRepos) => {
+  const selectAnalysisRepos = useCallback((allRepos) => {
     const byOrg = {}
     for (const repo of allRepos) {
       (byOrg[repo.orgLogin] ??= []).push(repo)
     }
-    const repos = Object.values(byOrg).flatMap(orgRepos =>
+    return Object.values(byOrg).flatMap(orgRepos =>
       pat ? orgRepos : getTopRepositories(orgRepos, 10)
     )
+  }, [pat])
+
+  // Shared issue-fetch logic: same repo-selection rule as contributors
+  const auditRepos = useCallback(async (allRepos) => {
+    const repos = selectAnalysisRepos(allRepos)
 
     const map = {}
     for (let i = 0; i < repos.length; i += 5) {
@@ -165,7 +171,7 @@ export function AppProvider({ children }) {
       }))
     }
     return map
-  }, [pat])
+  }, [pat, selectAnalysisRepos])
 
   // Governance audit : used directly when repos are already complete
   const runAudit = useCallback(async () => {
@@ -204,13 +210,28 @@ export function AppProvider({ children }) {
   }, [isComplete, model, runFullExplore, auditRepos, pat, govLoading])
 
   // Advanced analytics — parallel batches of 5 (Section 3.2.5)
+  // Entry point for Analytics "Run Complete Analysis"
+  // - If repos/contributors aren't complete yet -> fetch them first (explore),
+  //   then fetch pulls using the freshly-returned model (avoids stale closure).
+  // - If already complete -> skip repo fetching, just fetch pulls.
   const runAdvanceAnalytics = useCallback(async () => {
-    if (!model || advanceAnalyticsLoading) return
+    if (advanceAnalyticsLoading) return
+
+    let currentModel = model
+    if (!isComplete) {
+      setAdvanceAnalyticsLoading(true) // reflect "working" immediately
+      const freshModel = await runFullExplore()
+      setAdvanceAnalyticsLoading(false)
+      if (!freshModel) return
+      currentModel = freshModel
+    }
+
+    if (!currentModel) return
+
     setAdvanceAnalyticsLoading(true)
     const map = {}
-    const repos = model.totalRepos;
+    const repos = selectAnalysisRepos(currentModel.totalRepos)
 
-    // Batches of 5 using Promise.allSettled
     for (let i = 0; i < repos.length; i += 5) {
       const batch = repos.slice(i, i + 5)
       await Promise.allSettled(batch.map(async repo => {
@@ -219,7 +240,52 @@ export function AppProvider({ children }) {
     }
     setPullsData(map)
     setAdvanceAnalyticsLoading(false)
-  }, [model, pat, advanceAnalyticsLoading])
+    setAdvanceAnalyticsComplete(!!pat)
+  }, [isComplete, model, runFullExplore, selectAnalysisRepos, pat, advanceAnalyticsLoading])
+
+  // Combined entry point for the whole Analytics page banner
+  // Runs explore() once if needed, then fetches issues + pulls in parallel
+  const runFullAnalytics = useCallback(async () => {
+    if (govLoading || advanceAnalyticsLoading) return
+
+    let currentModel = model
+    if (!isComplete) {
+      setGovLoading(true)
+      setAdvanceAnalyticsLoading(true)
+      const freshModel = await runFullExplore()
+      setGovLoading(false)
+      setAdvanceAnalyticsLoading(false)
+      if (!freshModel) return
+      currentModel = freshModel
+    }
+
+    if (!currentModel) return
+
+    setGovLoading(true)
+    setAdvanceAnalyticsLoading(true)
+
+    const [issuesMap, pullsMap] = await Promise.all([
+      auditRepos(currentModel.allRepos),
+      (async () => {
+        const repos = selectAnalysisRepos(currentModel.totalRepos)
+        const map = {}
+        for (let i = 0; i < repos.length; i += 5) {
+          const batch = repos.slice(i, i + 5)
+          await Promise.allSettled(batch.map(async repo => {
+            map[`${repo.orgLogin}/${repo.name}`] = await fetchPulls(repo.orgLogin, repo.name, pat)
+          }))
+        }
+        return map
+      })()
+    ])
+
+    setIssuesData(issuesMap)
+    setPullsData(pullsMap)
+    setGovLoading(false)
+    setAdvanceAnalyticsLoading(false)
+    setAuditComplete(!!pat)
+    setAdvanceAnalyticsComplete(!!pat)
+  }, [model, isComplete, runFullExplore, auditRepos, selectAnalysisRepos, pat, govLoading, advanceAnalyticsLoading])
 
   const STALE_DAYS = 90
   
@@ -259,7 +325,8 @@ export function AppProvider({ children }) {
     <Ctx.Provider value={{
       pat, savePat, orgs, model, issuesData, pullsData,
       rateLimit, loading, loadMsg, govLoading, error, totalRepo,
-      runAdvanceAnalytics, refreshRateLimit, advanceAnalyticsLoading,
+      runAdvanceAnalytics, refreshRateLimit, advanceAnalyticsLoading, advanceAnalyticsComplete,
+      runFullAnalytics,
       isComplete, auditComplete, lastOrgNames,
       explore, runFullExplore, runAudit, runGovernanceAnalysis, setError, staleRepoStats
     }}>

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -22,7 +22,7 @@ const TOOLTIP_STYLE = {
 }
 
 export default function AnalyticsPage() {
-  const { model, issuesData, runAudit, govLoading, runAdvanceAnalytics, advanceAnalyticsLoading, pullsData,  auditComplete, loading, runGovernanceAnalysis  } = useApp()
+  const { model, issuesData, runAudit, govLoading, runAdvanceAnalytics, advanceAnalyticsLoading, advanceAnalyticsComplete, runFullAnalytics, pullsData,  auditComplete, loading, runGovernanceAnalysis, pat  } = useApp()
 
   const [granularity,   setGranularity]   = useState('monthly')
   const [selectedRepo, setSelectedRepo] = useState('All')
@@ -51,9 +51,10 @@ export default function AnalyticsPage() {
     return key ? (pullsData[key] || []) : []
   }, [pullsData, selectedRepoForAM])
 
-  if (!model) return null
 
   const advancedMetrics = useAdvancedMetrics(filteredPulls)
+
+  if (!model) return null
 
   const acceptanceChart = [
     {
@@ -66,8 +67,8 @@ export default function AnalyticsPage() {
     }
   ]
   
-  const repoNames = ['All', ...model.allRepos.slice(0, 12).map(r => r.name)]
-  const allRepoNames = ['All Repositories', ...model.totalRepos.map(r => r.name)];
+  const repoNames = ['All', ...Object.keys(issuesData || {}).map(k => k.split('/')[1])]
+  const allRepoNames = ['All Repositories', ...Object.keys(pullsData || {}).map(k => k.split('/')[1])]
   const hasData = Object.keys(issuesData || {}).length > 0
   const hasPullsData = Object.keys(pullsData || {}).length > 0
   const hasSeries = series.length > 0
@@ -89,20 +90,21 @@ export default function AnalyticsPage() {
     if (days <= 15) return 'var(--amber)'
     return 'var(--red)'
   }
+  const analyticsComplete = auditComplete && advanceAnalyticsComplete
   
   return (
     <>
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
       <AnalysisBanner
         page="governance"
-        description="Activity trends are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
-        analysisStatus={auditComplete ? 'complete' : 'sample'}
-        loading={loading || govLoading}
-        onRun={runGovernanceAnalysis}
+        description="Activity trends and advanced metrics are computed from a representative subset to balance speed and API usage. Connect a PAT to analyze every repository and access complete results."
+        analysisStatus={analyticsComplete ? 'complete' : 'sample'}
+        loading={loading || govLoading || advanceAnalyticsLoading}
+        onRun={runFullAnalytics}
       />
       <PageTitle
         title="Activity Trends"
-        subtitle="How PR and issue velocity is evolving over time — created, merged, and closed per week or month"
+        subtitle="How PR and issue velocity is evolving over time — created, merged, and closed per week or month."
         right={
           hasSeries && (
             <button
@@ -139,12 +141,14 @@ export default function AnalyticsPage() {
 
         {!hasData && (
           <button
-            onClick={runAudit}
-            disabled={govLoading}
+            onClick={() => pat ? runFullAnalytics() : runGovernanceAnalysis()}
+            disabled={govLoading || advanceAnalyticsLoading}
             style={{ ...C.btn('primary'), display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, opacity: govLoading ? 0.7 : 1 }}
           >
             <FiRefreshCw size={13} />
-            {govLoading ? 'Fetching issue history...' : 'Load Issue and PR History'}
+              {(govLoading || advanceAnalyticsLoading)
+              ? (pat ? 'Fetching full data...' : 'Fetching issue history...')
+              : 'Load Issue and PR History'}
           </button>
         )}
       </div>
@@ -168,7 +172,9 @@ export default function AnalyticsPage() {
       {govLoading && (
         <InfoBox>
           <div style={{ fontSize: 14, color: 'var(--text)' }}>
-            Fetching issue and PR history for top 15 repositories in batches of 5...
+            {pat
+            ? 'Fetching issue and PR history for all repositories in batches of 5...'
+            : 'Fetching issue and PR history for top 10 repositories in batches of 5...'}
           </div>
         </InfoBox>
       )}
@@ -225,7 +231,7 @@ export default function AnalyticsPage() {
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
       <PageTitle
         title="Advanced Analytics"
-        subtitle="Key metrics and trends for your organization, including PR acceptance rate and PR average merge time, and more (Please run analysis with PAT)."
+        subtitle="Key metrics and trends for your organization, including PR acceptance rate and PR average merge time, and more."
       />
         
       {/* Controls */}
@@ -278,15 +284,43 @@ export default function AnalyticsPage() {
           
         {!hasPullsData && (
           <button
-            onClick={() => runAdvanceAnalytics()}
-            disabled={advanceAnalyticsLoading}
+            onClick={() => pat ? runFullAnalytics() : runAdvanceAnalytics()}
+            disabled={govLoading || advanceAnalyticsLoading}
             style={{ ...C.btn('primary'), display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, opacity: advanceAnalyticsLoading ? 0.7 : 1 }}
           >
             <FiRefreshCw size={13} />
-            {advanceAnalyticsLoading ? 'Collecting...' : 'Collect Advanced Metrics'}
+              {(govLoading || advanceAnalyticsLoading)
+              ? (pat ? 'Fetching full data...' : 'Collecting...')
+              : 'Collect Advanced Metrics'}
           </button>
         )}
       </div>
+
+      {/* Empty state before audit runs */}
+      {!hasPullsData && !advanceAnalyticsLoading && (
+        <InfoBox>
+          <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)', marginBottom: 8 }}>
+            No Pull Request data loaded yet
+          </div>
+          <p style={{ fontSize: 13, marginBottom: 12 }}>
+            Click "Collect Advanced Metrics" above to fetch pull request data for the top repositories.
+          </p>
+          <p style={{ fontSize: 12 }}>
+            This computes average merge time and PR acceptance rate from each repository's pull
+            request history, with no additional API calls beyond the fetch itself.
+          </p>
+        </InfoBox>
+      )}
+
+      {advanceAnalyticsLoading && (
+        <InfoBox>
+          <div style={{ fontSize: 14, color: 'var(--text)' }}>
+            {pat
+            ? 'Fetching pull request history for all repositories in batches of 5...'
+            : 'Fetching pull request history for top 10 repositories in batches of 5...'}
+          </div>
+        </InfoBox>
+      )}
 
       {hasPullsData &&
         (<div

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -52,7 +52,6 @@ export default function GovernancePage() {
     const start = (stalePage - 1) * ITEMS_PER_PAGE
     return staleRepoStats.slice(start, start + ITEMS_PER_PAGE)
   }, [staleRepoStats, stalePage])
-  console.log(paginatedStaleRepos);
   // Flatten all issues and tag with repo/org
   const allIssues = useMemo(() => {
     const arr = []

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -49,7 +49,7 @@ export default function SettingsPage() {
   }, [])
 
   return (
-    <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }} className="fade-up">
+    <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
       <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 24 }}>Settings</h1>
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -124,7 +124,8 @@ export async function fetchIssues(org, repo, pat) {
 
 export async function fetchPulls(org, repo, pat) {
   const all = []
-  for(let page = 1; ; page++) {
+  const maxPages = pat ? 10 : 1
+  for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/pulls?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
     all.push(...data)


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #(issue number)
Problems:
- Issue dropdown was hardcoded to .slice(0, 12), capping visibility regardless of actual fetch.
- PR dropdown used model.totalRepos (unfiltered) regardless of PAT — showing many repos with zero PR data when no PAT was connected.
- Advanced Analytics had no loading state, and its empty-state copy was stale (typo in button name, and text describing issue bucketing instead of PR metrics).
- Both loading messages hardcoded "top 15 repositories" — not accurate to actual scoping (top 10/org or all repos/org).
- Clicking "Collect Advanced Metrics" after issues were already loaded caused the whole page to flicker (unmount/remount), since explore() cleared model/orgs synchronously and the page guards on if (!model) return null.

###  Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

Before:
<img width="1918" height="871" alt="Screenshot 2026-07-10 015652" src="https://github.com/user-attachments/assets/28261416-447f-4df8-86c9-fe3cbd2a6543" />
Recording:
https://github.com/user-attachments/assets/18e4cb73-c59d-4c2d-aa81-a812a70834d0

After:
<img width="1918" height="862" alt="Screenshot 2026-07-10 015714" src="https://github.com/user-attachments/assets/c1408d63-c3ad-49bf-8b44-bb43f2120cd8" />
Recording:
https://github.com/user-attachments/assets/29f44fea-3c9c-4e09-a212-ef2fa09be080

###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
Fixes:
- Both dropdowns now derive from actually-fetched data, not the raw model.
- PR metrics now follow the same trigger flow as Governance: runAdvanceAnalytics checks isComplete, re-explores if still sample-scoped, else skips straight to fetching. runFullAnalytics runs issues + pulls in parallel off the same resolved model, so both stay scoped to the same repo set.
- Added matching empty/loading states for Advanced Analytics, fixed stale copy, and made both sections hide their empty-state box while loading.
- Replaced hardcoded "top 15" with accurate PAT-aware text ("top 10 repositories" / "all repositories").
- Removed the premature setModel(null) / setOrgs([]) clear in explore() — data now swaps in atomically once ready, so the page no longer unmounts mid-refresh.

Repo Scoping Reference:
| Metric | No PAT (per org) | With PAT (per org) |
|---|---|---|
| Repos fetched | ≤500 | all (`public_repos` count) |
| Repos used for contributors/issues/pulls | 10 (top by weighted score) | all fetched repos |
| Contributors | ≤100/repo × 10 repos = ≤1,000/org | ≤1000/repo × all repos |
| Issues | ≤100/repo × 10 repos = ≤1,000/org | ≤1000/repo × all repos |
| Pull Requests | ≤100/repo × 10 repos = ≤1,000/org | ≤1000/repo × all repos |
## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.

https://github.com/user-attachments/assets/67494e33-14e0-40cc-95f1-0e46af703c27

