### PR TITLE
fix: only count open issues/PRs in governance audit

### DIFF
--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -71,7 +71,7 @@ export default function GovernancePage() {
 
   // Health check 1 — Dead Issues (>90 days open, not a PR)
   const deadIssues = allIssues
-    .filter(i => !i.pull_request && daysSince(i.created_at) >= 90)
+    .filter(i => !i.pull_request && i.state === 'open' && daysSince(i.created_at) >= 90)
     .sort((a, b) => daysSince(b.created_at) - daysSince(a.created_at))
 
   // Health check 2 — Percentage of dead issues relative to all issues
@@ -79,7 +79,7 @@ export default function GovernancePage() {
 
   // Health check 3 — Zombie PRs (>90 days open)
   const zombiePRs = allIssues
-    .filter(i => i.pull_request && daysSince(i.created_at) >= 90)
+    .filter(i => i.pull_request && i.state === 'open' && daysSince(i.created_at) >= 90)
     .sort((a, b) => daysSince(b.created_at) - daysSince(a.created_at))
 
   // Health check 4 — No license


### PR DESCRIPTION
The Dead Issues and Zombie PRs stats fetch issues with `state=all` but never
filter by state, so closed and merged items 90+ days old were counted despite
the "OPEN 90+ DAYS" / "PENDING 90+ DAYS" labels. This inflated the counts
(e.g. auditing reduxjs showed 511 zombie PRs when only 40 were actually open).

Added `i.state === 'open'` to both the deadIssues and zombiePRs filters in
`GovernancePage.jsx` so only currently-open items are counted.

### Addressed Issues:
Fixes #122

### Screenshots/Recordings:
Before / After (auditing `reduxjs`):

| Metric           | Before | After  |
|---------------|---------|-------|
| Dead Issues |   257     | 58     |
| Zombie PRs |   511     | 40     |

After Screenshot
<img width="1890" height="765" alt="Screenshot 2026-07-23 143739" src="https://github.com/user-attachments/assets/589390ff-035c-4b9a-bd44-6f85273f4d0b" />


### Additional Notes:
The remaining items are genuinely open (e.g. `redux-mock-store` #120 and #158
are open PRs), so they are correctly still counted. Only closed/merged items
were removed.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation (N/A — no docs affected)
- [x] My changes generate no new warnings or errors
- [x] I have joined the Discord server and I will share a link to this PR
- [x] I have read the Contributing Guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal health-check list processing without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->