### PR TITLE
Fix: Unbounded concurrent API requests in explore() causes Secondary Rate Limit (Abuse) bans

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -116,9 +116,13 @@ export function AppProvider({ children }) {
         const top = pat ? (reposPerOrg[org.login] || []) : getTopRepositories(reposPerOrg[org.login] || [], 10);
         reposPerOrg[org.login] = top;
 
-        await Promise.allSettled(top.map(async repo => {
-          contribsPerRepo[`${org.login}/${repo.name}`] = await fetchContributors(org.login, repo.name, pat)
-        }))
+        // Batch contributor requests to prevent API abuse limits
+        for (let i = 0; i < top.length; i += 5) {
+          const batch = top.slice(i, i + 5)
+          await Promise.allSettled(batch.map(async repo => {
+            contribsPerRepo[`${org.login}/${repo.name}`] = await fetchContributors(org.login, repo.name, pat)
+          }))
+        }
       }
 
       setLoadMsg('Building analytical data model...')


### PR DESCRIPTION
Fixes #124.

This PR adds a batching loop to the `explore()` function when fetching contributors. Previously, it fired off API requests for all repositories concurrently, which instantly triggered GitHub's secondary rate limits (abuse bans) for large organizations. The requests are now chunked in batches of 5, identical to the pattern used in `runAudit()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved contributor data loading during repository exploration by processing results in smaller groups.
  * Reduced request spikes, helping exploration remain more stable when reviewing organizations with many repositories.
  * Existing contributor totals and exploration behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->