### PR TITLE
fix: resolve the issue of network page regarding repo data

### DIFF
--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -9,7 +9,7 @@ import AnalysisBanner from '../components/AnalysisBanner'
 import { NetworkSkeleton } from '../components/Orgexplorerskeletons'
 
 export default function NetworkPage() {
-  const { model, isComplete, loading, runFullExplore } = useApp()
+  const { model, isComplete, loading, runFullExplore, allRepos } = useApp()
   const svgRef   = useRef(null)
   const simRef   = useRef(null)
   const [tooltip,      setTooltip]      = useState(null)
@@ -29,7 +29,20 @@ export default function NetworkPage() {
     svg.attr('viewBox', `0 0 ${W} ${H}`)
 
     // Top repos and contributors for performance
-    const topRepos    = model.allRepos.slice(0, 30)
+    // Top repos and contributors for performance
+    // allRepos entries don't carry healthScore/activityClassification —
+    // only totalRepos does (see buildAnalyticalModel) — so enrich them here
+    const repoMetaByKey = new Map(
+      model.totalRepos.map(r => [`${r.orgLogin}/${r.name}`, r])
+    )
+    const topRepos = model.allRepos.slice(0, 30).map(r => {
+      const meta = repoMetaByKey.get(`${r.orgLogin}/${r.name}`)
+      return {
+        ...r,
+        healthScore: meta?.healthScore ?? 0,
+        activityClassification: meta?.activityClassification ?? 'Unknown',
+      }
+    })
     const topContribs = model.contributors
 
     const nodes = []
@@ -150,6 +163,7 @@ export default function NetworkPage() {
         .attr('x2', d => d.target.x).attr('y2', d => d.target.y)
       node.attr('transform', d => `translate(${d.x},${d.y})`)
     })
+    console.log(tooltip)
 
     return () => sim.stop()
   }, [model, showRepos, showContribs])
@@ -214,7 +228,7 @@ export default function NetworkPage() {
                   </strong>
                 </div>
                 <div style={{ color: 'var(--text2)', marginBottom: 2 }}>Stars: {tooltip.node.data.stargazers_count?.toLocaleString()}</div>
-                <div style={{ color: 'var(--text2)' }}>Lifecycle: {tooltip.node.data.lifecycle}</div>
+                <div style={{ color: 'var(--text2)' }}>Activity: {tooltip.node.data.activityClassification}</div>
               </>
             ) : (
               <>


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #(issue number)
Bug related to the card of repositories.

###  Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
Before
<img width="1440" height="739" alt="WhatsApp Image 2026-08-01 at 22 50 20" src="https://github.com/user-attachments/assets/82111235-800f-4fd8-a332-1dafa4c3a04b" />

After
<img width="1917" height="887" alt="Screenshot 2026-08-01 223635" src="https://github.com/user-attachments/assets/7b849159-b42d-4794-9f22-9974b03b2af8" />

###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ ] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Repository nodes now display health scores and activity classifications.
  - Network tooltips show activity classification information for clearer repository insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->