### PR TITLE
fix: improve calendar picker icon visibility in Dark Mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,3 +62,18 @@ a { color: var(--accent); text-decoration: none; }
 .fade-up {
   animation: fadeUp 0.22s ease;
 }
+
+input[type="date"]::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+/* Dark theme */
+:root:not([data-theme="light"]) input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
+/* Light theme */
+[data-theme="light"] input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: none;
+}


### PR DESCRIPTION
### Addressed Issues
Fixes #144

### Changes
- Improved the visibility of the calendar picker icon in Dark Mode.
- Applied theme-specific styling so the icon remains clearly visible in both Light and Dark themes.

### Checklist
- [x] My code follows the project's code style and conventions.
- [x] My changes generate no new warnings or errors.
- [x] I have read the Contributing Guidelines.


### Screenshots

## Before

### Dark Mode


<img width="1483" height="335" alt="image" src="https://github.com/user-attachments/assets/22076a12-ed10-45b4-ae61-c79340c2f991" />

### Light Mode

<img width="1561" height="324" alt="image" src="https://github.com/user-attachments/assets/381a7663-1c34-48e5-83d4-7c7d390c0bb3" />

---

## After

### Dark Mode

<img width="1639" height="428" alt="image" src="https://github.com/user-attachments/assets/e9370852-3a62-4ee2-85cd-c6a8555e7d6e" />

### Light Mode

<img width="1715" height="357" alt="image" src="https://github.com/user-attachments/assets/809255d1-869e-4544-8bf5-93f92f9e591a" /> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved date picker calendar icons with clearer pointer interaction.
  * Added smooth visual transitions and theme-aware coloring for dark and light modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->