### PR TITLE
fix: close light theme date picker rule

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,6 +76,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* Light theme */
 [data-theme="light"] input[type="date"]::-webkit-calendar-picker-indicator {
   filter: none;
+}
+
 .navbar-link:hover {
   color: var(--accent) !important;
 }


### PR DESCRIPTION
### Addressed Issues
Fixes #144

### Changes
- Fixed the missing closing brace in the Light Mode date-picker CSS rule.
- Applied the mentor's review feedback.

### Checklist
- [x] My code follows the project's code style and conventions.
- [x] My changes generate no new warnings or errors.
- [x] I have read the Contributing Guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling for the light-theme date picker indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->