### PR TITLE
fix: style contributor back button

### DIFF
--- a/src/pages/ContributorProfilePage.jsx
+++ b/src/pages/ContributorProfilePage.jsx
@@ -413,7 +413,6 @@ export default function ContributorProfilePage() {
             gap: 6,
             fontSize: 12,
           }}
-          className="hover:text-(--text) transition"
         >
           <FiArrowLeft size={14} /> Back to Contributor Intelligence
         </button>

--- a/src/pages/ContributorProfilePage.jsx
+++ b/src/pages/ContributorProfilePage.jsx
@@ -407,9 +407,11 @@ export default function ContributorProfilePage() {
         <button
           onClick={() => navigate('/contributors')}
           style={{
-            background: 'none', border: 'none', color: 'var(--text2)',
-            display: 'flex', alignItems: 'center', gap: 6, fontSize: 13,
-            cursor: 'pointer', padding: '6px 0', marginBottom: 12
+            ...C.btn('primary'),
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 12,
           }}
           className="hover:text-(--text) transition"
         >


### PR DESCRIPTION
### Addressed Issues:

Fixes #155

### Screenshots

<img width="880" height="273" alt="image" src="https://github.com/user-attachments/assets/2beaa4a5-7395-4753-ad6f-3f90d1b2608e" />


Updated the "Back to Contributor Intelligence" link to match the button styling used by the "Export Contribution Report" button.

### Additional Notes:

- Improved visual consistency and visibility of the navigation button.
- No functional behavior was changed.

## Checklist

- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the back-navigation button to use the app’s standard primary button styling.
  * Reduced the button’s font size for a more compact appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->