### PR TITLE
feat: add lazy loading for application routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,8 @@ function AppContent() {
       <Suspense
         fallback={
           <div
+            role="status"
+            aria-label="Loading page"
             style={{
               minHeight: '60vh',
               display: 'flex',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,40 @@
-import React from 'react'
+import React, { lazy, Suspense } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { AppProvider } from './context/AppContext'
 import { ThemeProvider } from './context/ThemeContext'
-import Navbar          from './components/Navbar'
+import Navbar from './components/Navbar'
 import RateLimitBanner from './components/RateLimitBanner'
-import HomePage        from './pages/HomePage'
-import OverviewPage    from './pages/OverviewPage'
-import RepositoriesPage from './pages/RepositoriesPage'
-import ContributorsPage from './pages/ContributorsPage'
-import ContributorProfilePage from './pages/ContributorProfilePage'
-import NetworkPage     from './pages/NetworkPage'
-import AnalyticsPage   from './pages/AnalyticsPage'
-import GovernancePage  from './pages/GovernancePage'
-import SettingsPage    from './pages/SettingsPage'
 import Footer from './components/layout/Footer'
-import Support from './pages/Support'
+import { Spinner } from './components/UI'
+
+// Lazy-loaded pages
+const HomePage = lazy(() => import('./pages/HomePage'))
+const OverviewPage = lazy(() => import('./pages/OverviewPage'))
+const RepositoriesPage = lazy(() => import('./pages/RepositoriesPage'))
+const ContributorsPage = lazy(() => import('./pages/ContributorsPage'))
+const ContributorProfilePage = lazy(() => import('./pages/ContributorProfilePage'))
+const NetworkPage = lazy(() => import('./pages/NetworkPage'))
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
+const GovernancePage = lazy(() => import('./pages/GovernancePage'))
+const SettingsPage = lazy(() => import('./pages/SettingsPage'))
+const Support = lazy(() => import('./pages/Support'))
 
 function Layout({ children }) {
   return (
-    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
       <Navbar />
       <RateLimitBanner />
-      <main style={{ flex: 1 }}>{children}</main>
+
+      <main style={{ flex: 1 }}>
+        {children}
+      </main>
+
       <Footer />
     </div>
   )
@@ -30,19 +43,41 @@ function Layout({ children }) {
 function AppContent() {
   return (
     <Layout>
-      <Routes>
-        <Route path="/"             element={<HomePage />} />
-        <Route path="/overview"     element={<OverviewPage />} />
-        <Route path="/repositories" element={<RepositoriesPage />} />
-        <Route path="/contributors" element={<ContributorsPage />} />
-        <Route path="/contributors/:username" element={<ContributorProfilePage />} />
-        <Route path="/network"      element={<NetworkPage />} />
-        <Route path="/analytics"    element={<AnalyticsPage />} />
-        <Route path="/governance"   element={<GovernancePage />} />
-        <Route path="/settings"     element={<SettingsPage />} />
-        <Route path="/support-us"      element={<Support />} />
-        <Route path="*"             element={<Navigate to="/" replace />} />
-      </Routes>
+      <Suspense
+        fallback={
+          <div
+            style={{
+              minHeight: '60vh',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Spinner />
+          </div>
+        }
+      >
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/overview" element={<OverviewPage />} />
+          <Route path="/repositories" element={<RepositoriesPage />} />
+          <Route path="/contributors" element={<ContributorsPage />} />
+          <Route
+            path="/contributors/:username"
+            element={<ContributorProfilePage />}
+          />
+          <Route path="/network" element={<NetworkPage />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/governance" element={<GovernancePage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/support-us" element={<Support />} />
+
+          <Route
+            path="*"
+            element={<Navigate to="/" replace />}
+          />
+        </Routes>
+      </Suspense>
     </Layout>
   )
 }


### PR DESCRIPTION
### Addressed Issues:
Fixes  #140

### Additional Notes:
- Added lazy loading for application pages using React.lazy().
- Added Suspense fallback with a loading spinner.
- This reduces the initial bundle size and loads pages only when needed.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the Discord server and shared this PR with the maintainers
- [x] I have read the Contributing Guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Page components now load on demand, improving initial application loading.
* **User Experience**
  * A centered loading indicator appears while pages are loading.
* **Navigation**
  * Existing routes and fallback navigation behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->