### PR TITLE
feat: add back to top button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,8 @@ import GovernancePage  from './pages/GovernancePage'
 import SettingsPage    from './pages/SettingsPage'
 import Footer from './components/layout/Footer'
 import Support from './pages/Support'
+import BackToTop from './components/layout/BackToTop'
+
 
 function Layout({ children }) {
   return (
@@ -22,6 +24,7 @@ function Layout({ children }) {
       <Navbar />
       <RateLimitBanner />
       <main style={{ flex: 1 }}>{children}</main>
+      <BackToTop />
       <Footer />
     </div>
   )

--- a/src/components/layout/BackToTop.jsx
+++ b/src/components/layout/BackToTop.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { FaArrowUp } from "react-icons/fa6";
+
+export default function BackToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      title="Back to top"
+      style={{
+        position: "fixed",
+        bottom: "24px",
+        right: "24px",
+        zIndex: 50,
+        width: "42px",
+        height: "42px",
+        borderRadius: "50%",
+        border: "1px solid var(--border)",
+        background: "var(--surface)",
+        color: "var(--accent)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        boxShadow: "0 4px 14px rgba(0, 0, 0, 0.2)",
+        transition: "all 0.2s ease",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = "var(--accent)";
+        e.currentTarget.style.color = "var(--surface)";
+        e.currentTarget.style.transform = "translateY(-2px)";
+        e.currentTarget.style.boxShadow = "0 6px 18px rgba(0, 0, 0, 0.25)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = "var(--surface)";
+        e.currentTarget.style.color = "var(--accent)";
+        e.currentTarget.style.transform = "translateY(0)";
+        e.currentTarget.style.boxShadow = "0 4px 14px rgba(0, 0, 0, 0.2)";
+      }}
+    >
+      <FaArrowUp size={16} />
+    </button>
+  );
+}

--- a/src/components/layout/BackToTop.jsx
+++ b/src/components/layout/BackToTop.jsx
@@ -10,6 +10,7 @@ export default function BackToTop() {
     };
 
     window.addEventListener("scroll", handleScroll);
+    handleScroll();
 
     return () => {
       window.removeEventListener("scroll", handleScroll);


### PR DESCRIPTION
## Related Issue

Closes #170

## What does this PR do?

Adds a reusable Back to Top button that appears when users scroll down the page.

### Implemented

- Added a Back to Top button with an upward arrow icon.
- The button appears when users scroll down.
- Clicking the button smoothly scrolls the page back to the top.
- Added accessible `aria-label` and `title` attributes.
- Styled the button to match the existing UI.
- Integrated the component into the common application layout, making it available across all pages.

## Testing

Tested locally to verify:

- The button appears when scrolling down on pages.
- The button remains hidden when the user is near the top.
- Clicking the button smoothly scrolls the page back to the top.
- The button works across pages using the common layout.
- Existing functionality remains unchanged.


## Demo

https://github.com/user-attachments/assets/32b82e5b-4c56-40ff-b68e-eda04ec64b92



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a floating “Back to top” button that appears after scrolling down.
  - Clicking the button smoothly returns the page to the top.
  - Added hover styling and an upward arrow icon for clear visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->