### PR TITLE
feat: add organization filter to contributors

### DIFF
--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -312,7 +312,7 @@ export default function ContributorsPage() {
             {filtered.length} contributors found
           </span>
         </div>
-        {contributors?.length ?
+        {filtered?.length ?
           (<>
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
@@ -442,10 +442,15 @@ export default function ContributorsPage() {
             >
               <EmptyStateCard
                 SvgIcon={<FiDatabase size={36} color='var(--accent)' />}
-                title="No contributors found"
-                description="We couldn't find any contributor data for this organization. "
+                title={search.trim() ? 'No matching contributors' : 'No contributors found'}
+                description={
+                  search.trim()
+                    ? `No contributors match "${search}".`
+                    : "We couldn't find any contributor data for this organization."
+                }
                 buttonText="Go to Home"
-                onButtonClick={() => navigate('/')} />
+                onButtonClick={() => navigate('/')}
+              />
             </div>
           </>)}
       </div>

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -11,11 +11,12 @@ import AnalysisBanner from '../components/AnalysisBanner'
 import { ContributorSkeleton } from '../components/Orgexplorerskeletons'
 
 export default function ContributorsPage() {
-  const { model, isComplete, loading, runFullExplore } = useApp()
+  const { model, isComplete, loading, runFullExplore, orgs } = useApp()
   const [search, setSearch] = useState('')
   const [shown, setShown] = useState(20)
   const [openInfo, setOpenInfo] = useState(null)
-  const busFactorRef = useRef(null)
+  const [selectedOrg, setSelectedOrg] = useState('all')
+ const busFactorRef = useRef(null)
   const freshnessRef = useRef(null)
   const signalRef = useRef(null)
 
@@ -48,11 +49,38 @@ export default function ContributorsPage() {
   const navigate = useNavigate()
   const contributors = model?.contributors ?? []
 
-  const busFactor = useMemo(() => computeBusFactor(contributors), [contributors])
+  const organizationOptions = useMemo(() => {
+    return (orgs ?? []).map(org => org.login)
+  }, [orgs])
 
-  const filtered = useMemo(() =>
-    contributors.filter(c => !search || c.login.toLowerCase().includes(search.toLowerCase())),
-    [contributors, search])
+
+  
+
+  const scopedContributors = useMemo(() => {
+    if (selectedOrg === 'all') {
+      return contributors
+    }
+
+    return contributors.filter(contributor =>
+      contributor.orgs.includes(selectedOrg)
+    )
+  }, [contributors, selectedOrg])
+  
+  const busFactor = useMemo(
+    () => computeBusFactor(scopedContributors),
+    [scopedContributors]
+  )
+  const filtered = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase()
+
+    if (!normalizedSearch) {
+      return scopedContributors
+    }
+
+    return scopedContributors.filter(contributor =>
+      contributor.login.toLowerCase().includes(normalizedSearch)
+    )
+  }, [scopedContributors, search])
 
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'totalContribs', 'desc')
   const visible = sorted.slice(0, shown)
@@ -60,10 +88,22 @@ export default function ContributorsPage() {
   if(loading) return <ContributorSkeleton />
   if (!model) return null
 
-  const topActive = contributors.slice(0, 10).filter(c => c.freshness > 50).length
-  const freshPct = contributors.length ? Math.round(topActive / Math.min(10, contributors.length) * 100) : 0
-  const connectors = contributors.filter(c => c.isConnector)
-  const crossOrg = contributors.filter(c => c.isCrossOrg)
+  const topActive = scopedContributors
+    .slice(0, 10)
+    .filter(c => c.freshness > 50)
+    .length
+
+  const freshPct = scopedContributors.length
+    ? Math.round(
+      topActive / Math.min(10, scopedContributors.length) * 100
+    )
+    : 0
+
+  const connectors = scopedContributors.filter(
+    c => c.isConnector
+  )
+
+  const crossOrg = scopedContributors.filter(c => c.isCrossOrg)
 
   const riskColor = r => r === 'critical' ? 'var(--red)' : r === 'high' ? 'var(--amber)' : 'var(--green)'
   const riskBar = r => r === 'critical' ? '90%' : r === 'high' ? '60%' : '25%'
@@ -83,7 +123,7 @@ export default function ContributorsPage() {
         title="Contributor Intelligence"
         subtitle="Analyzing contribution patterns, coverage risk, and organizational health"
         right={
-          <button onClick={() => exportContributorsCSV(contributors)} style={{ ...C.btn('ghost'), fontSize: 12, display: 'flex', alignItems: 'center', gap: 5 }}>
+          <button onClick={() => exportContributorsCSV(filtered)} style={{ ...C.btn('ghost'), fontSize: 12, display: 'flex', alignItems: 'center', gap: 5 }}>
             <FiDownload size={13} /> Export CSV
           </button>
         }
@@ -245,6 +285,29 @@ export default function ContributorsPage() {
             placeholder="Search by username..."
             style={{ ...C.input, width: 220 }}
           />
+          {organizationOptions.length > 0 && (
+            <select
+              value={selectedOrg}
+              onChange={e => {
+                setSelectedOrg(e.target.value)
+                setShown(20)
+              }}
+              style={{
+                ...C.input,
+                width: 220,
+                cursor: 'pointer',
+              }}
+              aria-label="Filter contributors by organization"
+            >
+              <option value="all">All Contributors</option>
+
+              {organizationOptions.map(org => (
+                <option key={org} value={org}>
+                  {org}
+                </option>
+              ))}
+            </select>
+          )}
           <span style={{ fontSize: 12, color: 'var(--text2)' }}>
             {filtered.length} contributors found
           </span>


### PR DESCRIPTION
### Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #176 


### Screenshots

<img width="1391" height="846" alt="image" src="https://github.com/user-attachments/assets/443b469a-37d9-4543-b44b-55e784d8f6f6" />

<img width="1511" height="861" alt="image" src="https://github.com/user-attachments/assets/058a2d64-a38d-4368-bb18-790f02a1ba83" />

<img width="1530" height="855" alt="image" src="https://github.com/user-attachments/assets/2cf2bf21-1ec1-46cf-9bee-ed5f29279c34" />


<!-- Demonstrates the new organization filter:
- Default state shows "All Contributors"
- Selecting an organization filters contributors
- Selecting "All Contributors" restores the full contributor list
-->


### Additional Notes:

- Added a single-select organization dropdown to the Contributors page.
- The dropdown defaults to "All Contributors".
- Users can select one organization to view only its contributors.
- Contributor statistics and the table update based on the selected organization.
- Resetting the filter to "All Contributors" restores all contributors.
- Verified the production build with `npm run build`.


## Checklist

- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-based filtering for contributors.
  * Contributor metrics, search, sorting, exports, table visibility, and analytics now reflect the selected organization.
  * Pagination resets automatically when switching organizations.
  * Improved empty-state messaging to distinguish no search results from unavailable contributor data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->