### PR TITLE
Add organization filter dropdown to Repository Explorer

### DIFF
--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -18,6 +18,7 @@ export default function RepositoriesPage() {
   const [search, setSearch] = useState('')
   const [activityClassification, setActivityClassification] = useState('All')
   const [lang, setLang] = useState('All Languages')
+  const [orgFilter, setOrgFilter] = useState('All Organizations')
   const [shown, setShown] = useState(20)
   const [openInfo, setOpenInfo] = useState(false)
   const infoRef = useRef(null)
@@ -44,12 +45,17 @@ export default function RepositoriesPage() {
     ['All Languages', ...new Set(allRepos.map(r => r.language).filter(Boolean))].slice(0, 10),
     [allRepos])
 
+  const orgList = useMemo(() =>
+    ['All Organizations', ...new Set(allRepos.map(r => r.orgLogin).filter(Boolean))],
+    [allRepos])
+
   const filtered = useMemo(() => allRepos.filter(r =>
     (activityClassification === 'All' || r.activityClassification === activityClassification) &&
     (lang === 'All Languages' || r.language === lang) &&
+    (orgFilter === 'All Organizations' || r.orgLogin === orgFilter) &&
     (!search || r.name.toLowerCase().includes(search.toLowerCase()) ||
       (r.description || '').toLowerCase().includes(search.toLowerCase()))
-  ), [allRepos, activityClassification, lang, search])
+  ), [allRepos, activityClassification, lang, orgFilter, search])
 
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'healthScore', 'desc')
   const visible = sorted.slice(0, shown)
@@ -166,6 +172,15 @@ export default function RepositoriesPage() {
             placeholder="Filter by repository name or description..."
             style={{ ...C.input, flex: 1, minWidth: 200 }}
           />
+          {orgList.length > 2 && (
+            <select
+              value={orgFilter}
+              onChange={e => { setOrgFilter(e.target.value); setShown(20) }}
+              style={C.select}
+            >
+              {orgList.map(o => <option key={o}>{o}</option>)}
+            </select>
+          )}
           <select value={lang} onChange={e => setLang(e.target.value)} style={C.select}>
             {langs.map(l => <option key={l}>{l}</option>)}
           </select>

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -49,6 +49,11 @@ export default function RepositoriesPage() {
     ['All Organizations', ...new Set(allRepos.map(r => r.orgLogin).filter(Boolean))],
     [allRepos])
 
+  useEffect(() => {
+    setOrgFilter('All Organizations')
+    setShown(20)
+  }, [orgList])
+
   const filtered = useMemo(() => allRepos.filter(r =>
     (activityClassification === 'All' || r.activityClassification === activityClassification) &&
     (lang === 'All Languages' || r.language === lang) &&
@@ -177,6 +182,7 @@ export default function RepositoriesPage() {
               value={orgFilter}
               onChange={e => { setOrgFilter(e.target.value); setShown(20) }}
               style={C.select}
+              aria-label="Filter by organization"
             >
               {orgList.map(o => <option key={o}>{o}</option>)}
             </select>


### PR DESCRIPTION
### Addressed Issues:
Fixes #184

##  Recordings:

https://github.com/user-attachments/assets/5d611d68-3ed9-43d2-8eba-6ce2c51d6223

---

## sceenshot

Note: The dropdown options (e.g. "All Organizations", "google", "apple") aren't clearly visible...

<img width="1896" height="924" alt="image" src="https://github.com/user-attachments/assets/e7eedfe0-7cb8-4c32-91d7-a02df7635383" />

---

### Additional Notes:
Added an "Organization" filter dropdown to the Repository Explorer page (RepositoriesPage.jsx), following the same pattern as the existing "Language" filter.

Changes:
- Added `orgFilter` state to track the selected organization
- Added `orgList` (useMemo) to derive unique organizations from `orgLogin`, already present on repo objects — no new API calls needed
- Added `orgFilter` condition to the existing `filtered` useMemo, and included it in the dependency array
- Added the dropdown UI next to the Language filter, resetting pagination (`setShown(20)`) on change
- The dropdown only renders when more than one organization is present in the results (`orgList.length > 2`), so single-org searches are unaffected

Tested locally with multiple organizations searched together — filtering correctly narrows the repository list to the selected org, and works alongside the existing language filter, search box, and CSV export.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization filtering to the repositories page.
  * Added an organization selector when multiple organizations are available.
  * Pagination now resets automatically when the selected organization changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->