### PR TITLE
fix: add validation for localStorage theme values

### DIFF
--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -24,7 +24,11 @@ export function ThemeProvider({ children }) {
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
-    localStorage.setItem('oe_theme', theme)
+    try {
+      localStorage.setItem('oe_theme', theme)
+    } catch (error) {
+      console.warn('Failed to save theme to localStorage:', error)
+    }
   }, [theme])
 
   const toggleTheme = () => {

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -12,9 +12,10 @@ export function ThemeProvider({ children }) {
         return stored
       }
 
-      if (stored) {
+      if (stored !== null) {  
         console.warn(`Invalid theme value found in localStorage: "${stored}". Falling back to 'dark'.`)
       }
+
     } catch (error) {
       console.warn('Failed to read theme from localStorage:', error)
     }

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -3,8 +3,23 @@ import { createContext, useContext, useState, useEffect } from 'react'
 const ThemeCtx = createContext(null)
 
 export function ThemeProvider({ children }) {
+
   const [theme, setTheme] = useState(() => {
-    return localStorage.getItem('oe_theme') || 'dark'
+    try {
+      const stored = localStorage.getItem('oe_theme')
+
+      if (stored === 'dark' || stored === 'light') {
+        return stored
+      }
+
+      if (stored) {
+        console.warn(`Invalid theme value found in localStorage: "${stored}". Falling back to 'dark'.`)
+      }
+    } catch (error) {
+      console.warn('Failed to read theme from localStorage:', error)
+    }
+
+    return 'dark'
   })
 
   useEffect(() => {


### PR DESCRIPTION
## What this PR does
- Adds validation for theme values stored in localStorage
- Only accepts 'dark' or 'light' as valid themes
- Falls back to 'dark' for any invalid value
- Logs warning in console for debugging

## Why this is needed
The ThemeProvider was directly reading localStorage values without validation. If an invalid value like 'blue' or 'red' was stored, the app would use it as the theme, causing CSS variables to fail and UI to break.

## How to test
1. Run `localStorage.setItem('oe_theme', 'blue')` in console
2. Refresh page
3. UI should still work with dark theme
4. Console should show warning: `Invalid theme value found in localStorage: "blue". Falling back to 'dark'.`

## Test Cases
- ✅ `localStorage.setItem('oe_theme', 'dark')` → Dark theme loads
- ✅ `localStorage.setItem('oe_theme', 'light')` → Light theme loads
- ✅ `localStorage.setItem('oe_theme', 'blue')` → Falls back to dark + warning
- ✅ `localStorage.setItem('oe_theme', 'invalid')` → Falls back to dark + warning
- ✅ `localStorage.removeItem('oe_theme')` → Dark theme loads

Fixes #183

**Before (Bug):**
- Invalid theme value → Broken UI

**After (Fix):**
- Invalid theme value → Falls back to dark → UI works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme loading by accepting only supported light and dark settings.
  * Added a safe fallback to dark mode when saved theme data is invalid or unavailable.
  * Added warnings when theme preferences cannot be read or are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->