### PR TITLE
show +N indicator for hidden organizations on hover

### DIFF
--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -16,6 +16,7 @@ export default function OverviewPage() {
   const { orgs, model, totalRepo, isComplete, loading, runFullExplore } = useApp()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [showAllOrgs, setShowAllOrgs] = useState(false)
   const infoRef = useRef(null)
 
   useEffect(() => {
@@ -71,15 +72,57 @@ export default function OverviewPage() {
         loading={loading}
         onRun={runFullExplore}
       />
-
       {/* Org identity bar */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 28 }}>
         {isMulti ? (
-          <div style={{ display: 'flex' }}>
-            {orgs.slice(0, 3).map((o, i) => o.avatar_url && (
-              <img key={o.login} src={o.avatar_url} alt={o.login}
-                style={{ width: 36, height: 36, borderRadius: '50%', border: '2px solid var(--bg)', marginLeft: i ? -10 : 0 }} />
+          <div
+            style={{ display: 'flex', alignItems: 'center', cursor: orgs.length > 3 ? 'pointer' : 'default' }}
+            onMouseEnter={() => orgs.length > 3 && setShowAllOrgs(true)}
+            onMouseLeave={() => setShowAllOrgs(false)}
+          >
+            {orgs.map((o, i) => o.avatar_url && (
+              <div
+                key={o.login}
+                style={{
+                  width: (showAllOrgs || i < 3) ? 36 : 0,
+                  height: 36,
+                  overflow: 'hidden',
+                  borderRadius: '50%',
+                  marginLeft: i ? -10 : 0,
+                  transition: 'width 0.25s ease',
+                  flexShrink: 0,
+                }}
+              >
+                <img
+                  src={o.avatar_url}
+                  alt={o.login}
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: '50%',
+                    border: '2px solid var(--bg)',
+                  }}
+                />
+              </div>
             ))}
+            <div style={{
+              width: (!showAllOrgs && orgs.length > 3) ? 36 : 0,
+              height: 36,
+              overflow: 'hidden',
+              borderRadius: '50%',
+              marginLeft: 4,
+              transition: 'width 0.25s ease',
+              flexShrink: 0,
+            }}>
+              <div style={{
+                width: 36, height: 36, borderRadius: '50%',
+                background: 'var(--surface2)', border: '2px solid var(--bg)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 11, fontWeight: 600, color: 'var(--text2)',
+              }}>
+                +{orgs.length - 3}
+              </div>
+            </div>
           </div>
         ) : (
           orgs[0]?.avatar_url && (
@@ -103,9 +146,9 @@ export default function OverviewPage() {
               <FiExternalLink size={13} /> View on GitHub
             </a>
           )}
-          <SocialShareButton 
-            theme="dark" 
-            buttonStyle="ghost" 
+          <SocialShareButton
+            theme="dark"
+            buttonStyle="ghost"
             title={isMulti ? `OrgExplorer: ${orgs.map(o => o.login).join(' + ')}` : `OrgExplorer: ${orgs[0]?.name || orgs[0]?.login}`}
             description={isMulti ? `${orgs.length} organizations — combined portfolio view` : (orgs[0]?.description || `@${orgs[0]?.login}`)}
           />


### PR DESCRIPTION
### Addressed Issues:
Fixes #190

### Recordings:

https://github.com/user-attachments/assets/15fb8d34-985e-4ae8-9d3a-dc685cf41846




### Additional Notes:
Added a "+N" indicator in the Overview identity bar to show how many organizations are hidden when more than 3 are searched together.

Changes:
- Added `showAllOrgs` state to track hover expansion
- Each avatar is wrapped in a container with animated `width` (0 to 36px) so hidden avatars take up no space in the layout, avoiding
  gaps
- Hovering over the avatar group smoothly reveals all organization avatars via a CSS width transition; moving the mouse away collapses back to 3 avatars + the "+N" badge
- The "+N" badge itself is also width-animated, so it fades away cleanly when expanded, without leaving a gap
- Added `cursor: pointer` on the avatar group when more than 3 organizations are present, to signal it's interactive
- The badge only renders when `orgs.length > 3`, so single or few-org searches are unaffected

Tested locally with 4-5 organizations searched together — hover expand/collapse works smoothly with no layout shift or gaps.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)