### PR TITLE
feat: add organization filter for stats on Overview page

### DIFF
--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -16,6 +16,7 @@ export default function OverviewPage() {
   const { orgs, model, totalRepo, isComplete, loading, runFullExplore } = useApp()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [orgFilter, setOrgFilter] = useState('All Organizations')
   const infoRef = useRef(null)
 
   useEffect(() => {
@@ -35,16 +36,26 @@ export default function OverviewPage() {
 
   const { totalRepos } = model
   const isMulti = orgs.length > 1
-  const totalStars = totalRepos.reduce((s, r) => s + r.stargazers_count, 0)
-  const totalForks = totalRepos.reduce((s, r) => s + r.forks_count, 0)
-  const activeRepos = totalRepos.filter(r => r.activityClassification === 'Thriving' || r.activityClassification === 'Active').length
+
+  const filteredRepos = orgFilter === 'All Organizations'
+    ? totalRepos
+    : totalRepos.filter(r => r.orgLogin === orgFilter)
+
+  const totalStars = filteredRepos.reduce((s, r) => s + r.stargazers_count, 0)
+  const totalForks = filteredRepos.reduce((s, r) => s + r.forks_count, 0)
+  const activeRepos = filteredRepos.filter(r => r.activityClassification === 'Thriving' || r.activityClassification === 'Active').length
 
   const langMap = {}
-  totalRepos.forEach(r => { if (r.language) langMap[r.language] = (langMap[r.language] || 0) + 1 })
+  filteredRepos.forEach(r => { if (r.language) langMap[r.language] = (langMap[r.language] || 0) + 1 })
   const langs = Object.entries(langMap).sort((a, b) => b[1] - a[1]).slice(0, 7)
   const langTotal = langs.reduce((s, [, c]) => s + c, 0)
 
-  const topRepos = [...totalRepos].sort((a, b) => b.healthScore - a.healthScore).slice(0, 5)
+  const topRepos = [...filteredRepos].sort((a, b) => b.healthScore - a.healthScore).slice(0, 5)
+
+  useEffect(() => {
+    setOrgFilter('All Organizations')
+  }, [orgs])
+
 
   const NavCard = ({ to, label, sub }) => (
     <div
@@ -111,13 +122,31 @@ export default function OverviewPage() {
           />
         </div>
       </div>
+      {/* Org filter for stats */}
+      {isMulti && (
+        <div style={{ marginBottom: 16 }}>
+          <select
+            value={orgFilter}
+            onChange={e => setOrgFilter(e.target.value)}
+            style={C.select}
+            aria-label="Filter stats by organization"
+          >
+            <option>All Organizations</option>
+            {orgs.map(o => <option key={o.login}>{o.login}</option>)}
+          </select>
+        </div>
+      )}
 
       {/* Stats */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 12, marginBottom: 24 }}>
-        <StatCard label="Total Repos" value={formatNumber(totalRepo)} />
+        <StatCard label="Total Repos" value={formatNumber(orgFilter === 'All Organizations' ? totalRepo : filteredRepos.length)} />
         <StatCard label="Total Stars" value={formatNumber(totalStars)} />
         <StatCard label="Total Forks" value={formatNumber(totalForks)} />
-        <StatCard label="Active Repos" value={formatNumber(activeRepos)} sub={`${Math.round(activeRepos / totalRepo * 100)}% of total`} />
+        <StatCard
+          label="Active Repos"
+          value={formatNumber(activeRepos)}
+          sub={`${Math.round(activeRepos / (orgFilter === 'All Organizations' ? totalRepo : filteredRepos.length) * 100)}% of total`}
+        />
       </div>
 
       {/* Language + top repos */}

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -31,6 +31,10 @@ export default function OverviewPage() {
     }
   }, [])
 
+  useEffect(() => {
+    setOrgFilter('All Organizations')
+  }, [orgs])
+
   if(loading) return <OverviewSkeleton />
   if (!model) return null
 
@@ -52,9 +56,7 @@ export default function OverviewPage() {
 
   const topRepos = [...filteredRepos].sort((a, b) => b.healthScore - a.healthScore).slice(0, 5)
 
-  useEffect(() => {
-    setOrgFilter('All Organizations')
-  }, [orgs])
+ 
 
 
   const NavCard = ({ to, label, sub }) => (
@@ -145,7 +147,10 @@ export default function OverviewPage() {
         <StatCard
           label="Active Repos"
           value={formatNumber(activeRepos)}
-          sub={`${Math.round(activeRepos / (orgFilter === 'All Organizations' ? totalRepo : filteredRepos.length) * 100)}% of total`}
+          sub={`${(() => {
+            const total = orgFilter === 'All Organizations' ? totalRepo : filteredRepos.length
+            return total > 0 ? Math.round(activeRepos / total * 100) : 0
+          })()}% of total`}
         />
       </div>
 


### PR DESCRIPTION
### Addressed Issues:
Fixes #195

### Recordings:

https://github.com/user-attachments/assets/03ad0dbd-4e0a-4242-8e5f-1c41282790ee

---

### Screenshot : 
Note: The dropdown options aren't clearly visible in the recording, so attaching this screenshot to show the "All Organizations" filter
dropdown clearly:
 ---
<img width="1760" height="850" alt="image" src="https://github.com/user-attachments/assets/29645a52-16d9-4d65-8573-7dfe979c4c13" />


### Additional Notes:
Added an organization filter dropdown on the Overview page so users
can view stats for a single organization instead of only combined
totals across all searched organizations.

Changes:
- Added `orgFilter` state to track the selected organization
- Added `filteredRepos`, computed locally from `totalRepos` using the existing `orgLogin` field on each repo object — no new API calls needed
- Replaced `totalRepos` with `filteredRepos` in all stat calculations (Total Stars, Total Forks, Active Repos, Language Distribution, Top Repositories)
- Fixed the "Total Repos" count and "Active Repos" percentage to also use the filtered count instead of the unfiltered total when a specific org is selected
- Added the dropdown UI, shown only when more than one organization is present (`isMulti`), with an `aria-label` for accessibility
- Added a `useEffect` to reset the filter back to "All Organizations" whenever a new search is run, avoiding a stale filter from a
  previous search

Tested locally with 2+ organizations searched together — selecting an individual org correctly narrows every stat, and switching back to
"All Organizations" restores the combined view.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an organization filter for portfolio statistics when multiple organizations are being analyzed.
  * Selecting an organization updates repository counts, active repository metrics, star and fork totals, language distribution, and top repositories.
  * Added an “All Organizations” option to view combined statistics.
  * The filter automatically resets to “All Organizations” when the available organization list changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->