### PR TITLE
fix: show empty state when filters match zero repositories

### DIFF
--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -56,6 +56,7 @@ export default function ContributorsPage() {
 
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'totalContribs', 'desc')
   const visible = sorted.slice(0, shown)
+  const showNoSearchResults = search.trim() && filtered.length === 0 
 
   if(loading) return <ContributorSkeleton />
   if (!model) return null
@@ -249,8 +250,33 @@ export default function ContributorsPage() {
             {filtered.length} contributors found
           </span>
         </div>
-        {contributors?.length ?
-          (<>
+
+        {!contributors?.length && (
+          <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+            <EmptyStateCard
+              SvgIcon={<FiDatabase size={36} color='var(--accent)' />}
+              title="No contributors found"
+              description="We couldn't find any contributor data for this organization. "
+              buttonText="Go to Home"
+              onButtonClick={() => navigate('/')}
+            />
+          </div>
+        )}
+
+        {contributors?.length > 0 && showNoSearchResults && (
+          <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+            <EmptyStateCard
+              SvgIcon={<FiDatabase size={36} color='var(--accent)' />}
+              title="No matching contributors"
+              description="No contributors match your search. Try a different username."
+              buttonText="Clear Search"
+              onButtonClick={() => setSearch('')}
+            />
+          </div>
+        )}
+
+        {contributors?.length > 0 && !showNoSearchResults && (
+          <>
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr>
@@ -366,25 +392,11 @@ export default function ContributorsPage() {
                     </td>
                   </tr>
                 ))}
-              </tbody>
-            </table>
-            <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} /></>) :
-          (<>
-            <div
-              style={{
-                padding: '32px 24px',
-                maxWidth: 900,
-                margin: '0 auto',
-              }}
-            >
-              <EmptyStateCard
-                SvgIcon={<FiDatabase size={36} color='var(--accent)' />}
-                title="No contributors found"
-                description="We couldn't find any contributor data for this organization. "
-                buttonText="Go to Home"
-                onButtonClick={() => navigate('/')} />
-            </div>
-          </>)}
+            </tbody>
+          </table>
+        <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} />
+      </>
+        )}
       </div>
     </div >
   )

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -54,7 +54,7 @@ export default function RepositoriesPage() {
   const { sorted, sortConfig, onSort } = useSortedData(filtered, 'healthScore', 'desc')
   const visible = sorted.slice(0, shown)
 
-  if(loading) return <RepositorySkeleton />
+  if (loading) return <RepositorySkeleton />
   if (!model) return null
 
   const TABLE_COLS = [
@@ -65,6 +65,8 @@ export default function RepositoriesPage() {
     ['healthScore', 'Health'],
     ['pushed_at', 'Repository Activity'],
   ]
+
+  const showNoSearchResults = search.trim() && filtered.length === 0
 
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">
@@ -189,70 +191,77 @@ export default function RepositoriesPage() {
           ))}
         </div>
       </div>
-      {allRepos?.length ? (
-        <>
-          {/* Table view */}
-          <div style={{ ...C.card, padding: 0, overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr>
-                  {TABLE_COLS.map(([k, l]) => (
-                    <SortTh key={k} label={l} sortKey={k} sortConfig={sortConfig} onSort={onSort} />
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {visible.map((r, i) => (
-                  <tr key={r.id} style={{ borderBottom: '1px solid var(--border)', background: i % 2 ? 'var(--surface2)' : 'transparent' }}>
-                    <td style={{ padding: '10px 14px' }}>
-                      <a
-                        href={`${r.html_url}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          textDecoration: 'none',
-                          color: 'inherit',
-                        }}
-                      >
-                        <div style={{ fontWeight: 500, fontSize: 13 }}>{r.name}</div>
-                        {r.orgLogin && <div style={{ fontSize: 11, color: 'var(--text2)' }}>{r.orgLogin}</div>}
-                      </a>
-                    </td>
-                    <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.stargazers_count.toLocaleString()}</td>
-                    <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.forks_count.toLocaleString()}</td>
-                    <td style={{ padding: '10px 14px', fontSize: 13, color: r.open_issues_count > 30 ? 'var(--red)' : 'var(--text2)' }}>{r.open_issues_count}</td>
-                    <td style={{ padding: '10px 14px', minWidth: 130 }}><HealthBar score={r.healthScore} /></td>
-                    <td style={{ padding: '10px 14px' }}>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}><Badge text={r.activityClassification} />
-                        <span style={{ fontSize: 11, color: 'var(--text2)' }}>
-                          Last push: {r.pushed_at?.slice(0, 10)}
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
+
+      {!allRepos?.length && (
+        <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+          <EmptyStateCard
+            SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+            title="No repositories available"
+            description="We couldn't find any repositories for this organization yet."
+            buttonText="Go to Home"
+            onButtonClick={() => navigate('/')}
+          />
+        </div>
+      )}
+
+      {allRepos?.length > 0 && showNoSearchResults && (
+        <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+          <EmptyStateCard
+            SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+            title="No matching repositories"
+            description="No repositories match your search. Try a different search term."
+            buttonText="Clear Search"
+            onButtonClick={() => setSearch('')}
+          />
+        </div>
+      )}
+
+      {allRepos?.length > 0 && !showNoSearchResults && (
+        <div style={{ ...C.card, padding: 0, overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {TABLE_COLS.map(([k, l]) => (
+                  <SortTh key={k} label={l} sortKey={k} sortConfig={sortConfig} onSort={onSort} />
                 ))}
-              </tbody>
-            </table>
-            <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} />
-          </div>
-        </>)
-        : (
-          <div
-            style={{
-              padding: '32px 24px',
-              maxWidth: 900,
-              margin: '0 auto',
-            }}
-          >
-            <EmptyStateCard
-              SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
-              title="No repositories available"
-              description="We couldn't find any repositories for this organization yet."
-              buttonText="Go to Home"
-              onButtonClick={() => navigate('/')}
-            />
-          </div>
-        )}
-    </div>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((r, i) => (
+                <tr key={r.id} style={{ borderBottom: '1px solid var(--border)', background: i % 2 ? 'var(--surface2)' : 'transparent' }}>
+                 <td style={{ padding: '10px 14px' }}>
+  <a
+    href={`${r.html_url}`}
+    target="_blank"
+    rel="noopener noreferrer"
+    style={{
+      textDecoration: 'none',
+      color: 'inherit',
+    }}
+  >
+    <div style={{ fontWeight: 500, fontSize: 13 }}>{r.name}</div>
+    {r.orgLogin && <div style={{ fontSize: 11, color: 'var(--text2)' }}>{r.orgLogin}</div>}
+  </a>
+</td>
+                  <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.stargazers_count.toLocaleString()}</td>
+                  <td style={{ padding: '10px 14px', fontSize: 13, color: 'var(--text2)' }}>{r.forks_count.toLocaleString()}</td>
+                  <td style={{ padding: '10px 14px', fontSize: 13, color: r.open_issues_count > 30 ? 'var(--red)' : 'var(--text2)' }}>{r.open_issues_count}</td>
+                  <td style={{ padding: '10px 14px', minWidth: 130 }}><HealthBar score={r.healthScore} /></td>
+                  <td style={{ padding: '10px 14px' }}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}><Badge text={r.activityClassification} />
+                      <span style={{ fontSize: 11, color: 'var(--text2)' }}>
+                        Last push: {r.pushed_at?.slice(0, 10)}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <LoadMore shown={shown} total={sorted.length} onLoad={() => setShown(s => s + 20)} />
+        </div>
+  )
+}
+    </div >
   )
 }


### PR DESCRIPTION
### Addressed Issues:
Fixes #193

### Screenshots/Recordings:


https://github.com/user-attachments/assets/1529ef14-35d0-4edd-9a20-2d659e17b495


### Additional Notes:
Fixed an issue where searching for a repository name/description that matched zero results left the table showing only the header row with no explanation, since the empty-state check was based on the unfiltered repository count rather than the filtered result count.

Changes:
- Added a `showNoSearchResults` flag, true only when the user has  typed a non-empty search term AND it matches zero repositories
- Split the page's bottom section into three independent conditional  blocks: no repositories at all (existing "Go to Home" state), no  search matches (new "No matching repositories" state with a "Clear Search" button), and the normal table view
- The new empty state is scoped specifically to the search box — changing only the language or activity filters (without typing a
  search term) does not trigger it, keeping existing filter behavior unchanged

Tested locally: loading the page with no search shows the full list as before, typing a non-matching search term shows the new empty state, and clicking "Clear Search" restores the full list.

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository and contributor search states for clearer feedback.
  - Added a dedicated empty state when a repository search returns no matches.
  - Added handling for contributor searches that return no matching results.
  - Preserved separate empty states for accounts with no repositories.
  - Updated repository table visibility so it appears only when matching results are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->