### PR TITLE
fix: serve SPA shell for deep links on GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,9 +3,39 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { vitest } from "vitest";
 import svgr from "vite-plugin-svgr";
+import { copyFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * GitHub Pages serves static files only — it has no rewrite rule to map client-side
+ * routes back to the app shell. So a direct visit to (or a reload of) a route such as
+ * /overview or /contributors requests a file that does not exist on disk and Pages
+ * returns its default "File not found" page instead of the app.
+ *
+ * Emitting 404.html as a copy of index.html is the documented workaround: Pages serves
+ * that file for any unmatched path, the app boots, and React Router resolves the route
+ * from window.location. The URL is preserved, so there is no redirect and no flash.
+ */
+function spaDeepLinkFallback() {
+  let outDir;
+
+  return {
+    name: "spa-deep-link-fallback",
+    apply: "build",
+    configResolved(config) {
+      outDir = resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      const indexHtml = resolve(outDir, "index.html");
+      if (existsSync(indexHtml)) {
+        copyFileSync(indexHtml, resolve(outDir, "404.html"));
+      }
+    },
+  };
+}
 
 export default defineConfig(({ mode }) => ({
-  plugins: [react(), tailwindcss(), svgr()],
+  plugins: [react(), tailwindcss(), svgr(), spaDeepLinkFallback()],
   base: "/",
   test: {
     globals: true,


### PR DESCRIPTION
###  Addressed Issues:
Fixes #202

### What was wrong

`App.jsx` uses `BrowserRouter` with real paths, but GitHub Pages serves static files only and has no rewrite rule mapping unknown paths back to the app shell. So a direct visit to — or a **reload** of — `/overview`, `/contributors`, `/governance`, etc. requested a file that does not exist on disk and Pages returned its own "File not found" page. The app never booted.

This also meant the **Share** button produced links that 404'd for the recipient, and `sitemap.xml` entries were uncrawlable.

### The fix

One build-time plugin in `vite.config.js` that emits `404.html` as a copy of `index.html`.

GitHub Pages serves `404.html` for any unmatched path, so the app boots and React Router resolves the route from `window.location`. **The URL is preserved — there is no redirect and no flash**, which is why this is preferred over the older `?redirect=` query-string workaround.

No runtime code changed, no dependency added, no change to the deploy workflow. Local `npm run dev` and `npm run preview` already had this behaviour via Vite's dev server; this closes the gap for the production Pages build.

### Verification

| Check | Result |
|---|---|
| `npm run build` | ✅ passes |
| `npm test` | ✅ **40/40 passing** (4 files) |
| `dist/404.html` emitted | ✅ present |
| `cmp dist/404.html dist/index.html` | ✅ byte-identical |
| `GET /overview` under GitHub Pages semantics | ✅ serves app shell (`id="root"`), React Router resolves the route |
| Files changed | ✅ `vite.config.js` only |

Verified with a local static server replicating GitHub Pages' behaviour (serve the file if it exists, otherwise serve `404.html`), then loaded `http://localhost:8099/overview` in a real browser — the OrgExplorer shell renders instead of the Pages 404.

> Note: Pages still returns HTTP status `404` on the fallback response. That is inherent to this approach and does not affect rendering — the browser executes the returned document normally. This is the standard, GitHub-documented pattern for SPAs on Pages.

###  Additional Notes:
- Unrelated observation while testing: `CONTRIBUTING.md` asks contributors to run `npm run lint`, but `package.json` has no `lint` script (available: `dev`, `build`, `preview`, `test`, `coverage`). Happy to fix that separately if useful.

## Checklist
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

AI assistance was used to diagnose and implement this change. The root cause was reproduced on the live site, the fix was verified locally against a server replicating GitHub Pages' static-serving behaviour, and the full build and test suite were run before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation for direct links and deep pages when the app is hosted on GitHub Pages.
  * Added a fallback so unknown routes can load the application correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->