### PR TITLE
Fix Share button visibility in light mode

### DIFF
--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -8,12 +8,14 @@ import { AiOutlineInfoCircle } from "react-icons/ai";
 import AnalysisBanner from '../components/AnalysisBanner'
 import { OverviewSkeleton } from '../components/Orgexplorerskeletons'
 import {formatNumber} from '../utils/formatNumber'
+import { useTheme } from '../context/ThemeContext'
 
 const LANG_COLORS = ['#22c55e', '#f5c518', '#3b82f6', '#ef4444', '#a855f7', '#f97316', '#06b6d4']
 const fmt = n => n > 999 ? (n / 1000).toFixed(1) + 'k' : String(n)
 
 export default function OverviewPage() {
   const { orgs, model, totalRepo, isComplete, loading, runFullExplore } = useApp()
+  const { theme } = useTheme()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const infoRef = useRef(null)
@@ -104,8 +106,8 @@ export default function OverviewPage() {
             </a>
           )}
           <SocialShareButton 
-            theme="dark" 
-            buttonStyle="ghost" 
+            theme={theme}
+           buttonStyle={theme === 'dark' ? 'default' : 'light'}
             title={isMulti ? `OrgExplorer: ${orgs.map(o => o.login).join(' + ')}` : `OrgExplorer: ${orgs[0]?.name || orgs[0]?.login}`}
             description={isMulti ? `${orgs.length} organizations — combined portfolio view` : (orgs[0]?.description || `@${orgs[0]?.login}`)}
           />


### PR DESCRIPTION
## Description

The Share button on the Organization Overview page was not properly visible in Light Mode. The Share functionality was still working, but the button styling was not matching the current theme.

## What I changed

I made the Share button theme aware by using the current theme from ThemeContext.

Dark Mode uses the default Share button style, while Light Mode uses the light button style.

```jsx
buttonStyle={theme === 'dark' ? 'default' : 'light'}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Social sharing buttons now automatically adapt to the current light or dark theme.
  - Improved button styling and visibility across different theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->