### PR TITLE
fix: restore active organization state on page refresh and add empty …

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -55,11 +55,61 @@ export function AppProvider({ children }) {
     }
   })
 
+  const [hydrating, setHydrating] = useState(true)
+  const restoredFromCache = useRef(false)
+
+  // Restore the last analysis on startup from IndexedDB
   useEffect(() => {
-    if (lastOrgNames.length > 0 && !model && !loading) {
+    let cancelled = false
+
+    loadAnalysis()
+      .then(cached => {
+        if (cancelled || !cached) return
+
+        restoredFromCache.current = true
+
+        setOrgs(cached.orgs || [])
+        setModel(cached.model)
+        setTotalRepo(cached.totalRepo || 0)
+        setIsComplete(!!cached.isComplete)
+        if (cached.lastOrgNames?.length) {
+          setLastOrgNames(cached.lastOrgNames)
+        }
+        setIssuesData(cached.issuesData || {})
+        setPullsData(cached.pullsData || {})
+        setAuditComplete(!!cached.auditComplete)
+        setAdvanceAnalyticsComplete(!!cached.advanceAnalyticsComplete)
+      })
+      .finally(() => {
+        if (!cancelled) setHydrating(false)
+      })
+
+    return () => { cancelled = true }
+  }, [])
+
+  // Persist the analysis whenever it changes
+  useEffect(() => {
+    if (hydrating || !model) return
+
+    if (restoredFromCache.current) {
+      restoredFromCache.current = false
+      return
+    }
+
+    saveAnalysis({
+      orgs, model, totalRepo, isComplete, lastOrgNames,
+      issuesData, pullsData, auditComplete, advanceAnalyticsComplete
+    })
+  }, [
+    hydrating, orgs, model, totalRepo, isComplete, lastOrgNames,
+    issuesData, pullsData, auditComplete, advanceAnalyticsComplete
+  ])
+
+  useEffect(() => {
+    if (!hydrating && lastOrgNames.length > 0 && !model && !loading) {
       explore(lastOrgNames)
     }
-  }, [])
+  }, [hydrating])
 
   useEffect(() => {
     const handler = e => {

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -44,7 +44,12 @@ export function AppProvider({ children }) {
   const [lastOrgNames, setLastOrgNames] = useState(() => {
     try {
       const stored = localStorage.getItem('oe_active_orgs')
-      return stored ? JSON.parse(stored) : []
+      if (!stored) return []
+      const parsed = JSON.parse(stored)
+      if (Array.isArray(parsed)) {
+        return parsed.filter(item => typeof item === 'string' && item.trim().length > 0)
+      }
+      return []
     } catch {
       return []
     }
@@ -59,7 +64,9 @@ export function AppProvider({ children }) {
   useEffect(() => {
     const handler = e => {
       setRateLimit(e.detail)
-      localStorage.setItem('oe_rate_limit', JSON.stringify(e.detail))
+      try {
+        localStorage.setItem('oe_rate_limit', JSON.stringify(e.detail))
+      } catch {}
     }
 
     window.addEventListener('rate-limit-update', handler)
@@ -73,7 +80,9 @@ export function AppProvider({ children }) {
     if (!rateLimit?.reset) return
 
     const timeout = setTimeout(() => {
-      localStorage.removeItem('oe_rate_limit')
+      try {
+        localStorage.removeItem('oe_rate_limit')
+      } catch {}
       setRateLimit(null)
     }, Math.max(0, rateLimit.reset * 1000 - Date.now()))
 
@@ -90,7 +99,9 @@ export function AppProvider({ children }) {
   }, [pat])
   const savePat = useCallback(token => {
     setPat(token)
-    token ? localStorage.setItem('oe_pat', token) : localStorage.removeItem('oe_pat')
+    try {
+      token ? localStorage.setItem('oe_pat', token) : localStorage.removeItem('oe_pat')
+    } catch {}
   }, [])
 
   // Multi-org explore
@@ -102,7 +113,9 @@ export function AppProvider({ children }) {
     setIssuesData({});
     setLastOrgNames(orgNames);
     if (orgNames?.length) {
-      localStorage.setItem('oe_active_orgs', JSON.stringify(orgNames))
+      try {
+        localStorage.setItem('oe_active_orgs', JSON.stringify(orgNames))
+      } catch {}
     }
     setAuditComplete(false);
     setAdvanceAnalyticsComplete(false);
@@ -144,10 +157,12 @@ export function AppProvider({ children }) {
 
       setIsComplete(!!pat)
 
-      // Save to recent searches
-      const prev = JSON.parse(localStorage.getItem('oe_recent') || '[]')
-      const entry = orgNames.join(', ')
-      localStorage.setItem('oe_recent', JSON.stringify([...new Set([entry, ...prev])].slice(0, 6)))
+      // Save to recent searches (best-effort)
+      try {
+        const prev = JSON.parse(localStorage.getItem('oe_recent') || '[]')
+        const entry = orgNames.join(', ')
+        localStorage.setItem('oe_recent', JSON.stringify([...new Set([entry, ...prev])].slice(0, 6)))
+      } catch {}
       return builtModel
     } catch (err) {
       setError(err.message === 'RATE_LIMIT'

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -40,7 +40,20 @@ export function AppProvider({ children }) {
   const [advanceAnalyticsComplete, setAdvanceAnalyticsComplete] = useState(false) 
   const [isComplete, setIsComplete] = useState(false)
   const [auditComplete, setAuditComplete] = useState(false)
-  const [lastOrgNames, setLastOrgNames] = useState([])
+  const [lastOrgNames, setLastOrgNames] = useState(() => {
+    try {
+      const stored = localStorage.getItem('oe_active_orgs')
+      return stored ? JSON.parse(stored) : []
+    } catch {
+      return []
+    }
+  })
+
+  useEffect(() => {
+    if (lastOrgNames.length > 0 && !model && !loading) {
+      explore(lastOrgNames)
+    }
+  }, [])
 
   useEffect(() => {
     const handler = e => {
@@ -87,6 +100,9 @@ export function AppProvider({ children }) {
     setOrgs([]);
     setIssuesData({});
     setLastOrgNames(orgNames);
+    if (orgNames?.length) {
+      localStorage.setItem('oe_active_orgs', JSON.stringify(orgNames))
+    }
     setAuditComplete(false);
     setAdvanceAnalyticsComplete(false);
     try {

--- a/src/context/AppContext.test.jsx
+++ b/src/context/AppContext.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { AppProvider, useApp } from './AppContext'
+
+// Mock services to avoid network requests
+vi.mock('../services/github', () => ({
+  fetchOrg: vi.fn().mockResolvedValue({ login: 'test-org', public_repos: 5 }),
+  fetchRepos: vi.fn().mockResolvedValue([{ name: 'test-repo', orgLogin: 'test-org' }]),
+  fetchContributors: vi.fn().mockResolvedValue([]),
+  fetchIssues: vi.fn().mockResolvedValue([]),
+  fetchRateLimit: vi.fn().mockResolvedValue(null),
+  fetchPulls: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('../services/analytics', () => ({
+  buildAnalyticalModel: vi.fn().mockReturnValue({ allRepos: [], totalRepos: [] }),
+  getTopRepositories: vi.fn().mockImplementation(repos => repos)
+}))
+
+describe('AppContext - localStorage safety and validation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('handles invalid or non-array oe_active_orgs gracefully', async () => {
+    // Test with string value
+    localStorage.setItem('oe_active_orgs', JSON.stringify('invalid_string'))
+    const { result: res1 } = renderHook(() => useApp(), { wrapper: AppProvider })
+    expect(res1.current.lastOrgNames).toEqual([])
+
+    // Test with null
+    localStorage.setItem('oe_active_orgs', JSON.stringify(null))
+    const { result: res2 } = renderHook(() => useApp(), { wrapper: AppProvider })
+    expect(res2.current.lastOrgNames).toEqual([])
+
+    // Test with mixed array including invalid items
+    localStorage.setItem('oe_active_orgs', JSON.stringify(['valid-org', null, 123, '  ', 'another-org']))
+    let res3
+    await act(async () => {
+      res3 = renderHook(() => useApp(), { wrapper: AppProvider })
+    })
+    expect(res3.result.current.lastOrgNames).toEqual(['valid-org', 'another-org'])
+  })
+
+  it('isolates localStorage setItem failure in explore when saving oe_active_orgs', async () => {
+    const originalSetItem = localStorage.setItem
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, val) => {
+      if (key === 'oe_active_orgs') {
+        throw new Error('QuotaExceededError')
+      }
+      return originalSetItem.call(localStorage, key, val)
+    })
+
+    const { result } = renderHook(() => useApp(), { wrapper: AppProvider })
+
+    let modelResult
+    await act(async () => {
+      modelResult = await result.current.explore(['test-org'])
+    })
+
+    expect(modelResult).toBeTruthy()
+    expect(result.current.orgs).toHaveLength(1)
+  })
+
+  it('isolates localStorage setItem failure in explore when saving oe_recent', async () => {
+    const originalSetItem = localStorage.setItem
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, val) => {
+      if (key === 'oe_recent') {
+        throw new Error('QuotaExceededError')
+      }
+      return originalSetItem.call(localStorage, key, val)
+    })
+
+    const { result } = renderHook(() => useApp(), { wrapper: AppProvider })
+
+    let modelResult
+    await act(async () => {
+      modelResult = await result.current.explore(['test-org'])
+    })
+
+    expect(modelResult).toBeTruthy()
+    expect(result.current.error).toBe('')
+  })
+})

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell,  RadialBarChart, RadialBar, PolarAngleAxis } from 'recharts'
-import { FiDownload, FiRefreshCw } from 'react-icons/fi'
+import { FiDownload, FiRefreshCw, FiDatabase } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, PageTitle, InfoBox } from '../components/UI'
 import { buildTimeSeries, exportTrendsCSV } from '../services/analytics'
@@ -9,6 +10,7 @@ import { IoChevronDown } from 'react-icons/io5'
 import { HiCheck, HiOutlineClock } from 'react-icons/hi'
 import { useAdvancedMetrics } from '../hooks/useSortedData'
 import AnalysisBanner from '../components/AnalysisBanner'
+import EmptyStateCard from '../components/EmptyStateCard'
 import { AnalyticsSkeleton } from '../components/Orgexplorerskeletons'
 
 const TOOLTIP_STYLE = {
@@ -23,6 +25,7 @@ const TOOLTIP_STYLE = {
 }
 
 export default function AnalyticsPage() {
+  const navigate = useNavigate()
   const { model, issuesData, runAudit, govLoading, runAdvanceAnalytics, advanceAnalyticsLoading, advanceAnalyticsComplete, runFullAnalytics, pullsData,  auditComplete, loading, runGovernanceAnalysis, pat  } = useApp()
 
   const [granularity,   setGranularity]   = useState('monthly')
@@ -55,7 +58,19 @@ export default function AnalyticsPage() {
   const advancedMetrics = useAdvancedMetrics(filteredPulls)
 
   if(loading) return <AnalyticsSkeleton />
-  if (!model) return null
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view velocity and trend analytics."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
 
   const acceptanceChart = [
     {

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -58,7 +58,19 @@ export default function ContributorsPage() {
   const visible = sorted.slice(0, shown)
 
   if(loading) return <ContributorSkeleton />
-  if (!model) return null
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view contributor data."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
 
   const topActive = contributors.slice(0, 10).filter(c => c.freshness > 50).length
   const freshPct = contributors.length ? Math.round(topActive / Math.min(10, contributors.length) * 100) : 0

--- a/src/pages/GovernancePage.jsx
+++ b/src/pages/GovernancePage.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useMemo } from 'react'
-import { FiRefreshCw, FiExternalLink } from 'react-icons/fi'
+import { useNavigate } from 'react-router-dom'
+import { FiRefreshCw, FiExternalLink, FiDatabase } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, PageTitle, EmptyOk } from '../components/UI'
 import AnalysisBanner from '../components/AnalysisBanner'
+import EmptyStateCard from '../components/EmptyStateCard'
 import { GovernanceSkeleton } from '../components/Orgexplorerskeletons'
 
 const TABS = [
@@ -42,16 +44,17 @@ const getStatus = ratio => {
 }
 
 export default function GovernancePage() {
-  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis,staleRepoStats } = useApp()
+  const navigate = useNavigate()
+  const { model, issuesData, runAudit, govLoading, auditComplete, loading, runGovernanceAnalysis, staleRepoStats } = useApp()
   const [tab, setTab] = useState('dead')
 
   const ITEMS_PER_PAGE = 10
   const [stalePage, setStalePage] = useState(1)
-  const totalPages = Math.ceil(staleRepoStats.length / ITEMS_PER_PAGE)
+  const totalPages = Math.ceil((staleRepoStats?.length || 0) / ITEMS_PER_PAGE)
 
   const paginatedStaleRepos = useMemo(() => {
     const start = (stalePage - 1) * ITEMS_PER_PAGE
-    return staleRepoStats.slice(start, start + ITEMS_PER_PAGE)
+    return (staleRepoStats || []).slice(start, start + ITEMS_PER_PAGE)
   }, [staleRepoStats, stalePage])
   // Flatten all issues and tag with repo/org
   const allIssues = useMemo(() => {
@@ -63,8 +66,20 @@ export default function GovernancePage() {
     return arr
   }, [issuesData])
 
-  if(loading) return <GovernanceSkeleton />
-  if (!model) return null
+  if (loading) return <GovernanceSkeleton />
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view governance audit insights."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
 
   const hasAudit = Object.keys(issuesData || {}).length > 0
   const daysSince = d => Math.floor((Date.now() - new Date(d)) / 86_400_000)

--- a/src/pages/NetworkPage.jsx
+++ b/src/pages/NetworkPage.jsx
@@ -169,7 +169,20 @@ export default function NetworkPage() {
   }, [model, showRepos, showContribs])
 
   const navigate = useNavigate()
-  if(loading) return <NetworkSkeleton />
+  if (loading) return <NetworkSkeleton />
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view network graph relationships."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
   
   return (
     <div style={{ padding: '32px 24px', maxWidth: 1100, margin: '0 auto' }} className="fade-up">

--- a/src/pages/OverviewPage.jsx
+++ b/src/pages/OverviewPage.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { FiExternalLink, FiShare2, FiArrowRight } from 'react-icons/fi'
+import { FiExternalLink, FiShare2, FiArrowRight, FiDatabase } from 'react-icons/fi'
 import { useApp } from '../context/AppContext'
 import { C, StatCard, HealthBar } from '../components/UI'
 import SocialShareButton from '../components/SocialShareButton';
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import AnalysisBanner from '../components/AnalysisBanner'
+import EmptyStateCard from '../components/EmptyStateCard'
 import { OverviewSkeleton } from '../components/Orgexplorerskeletons'
 import {formatNumber} from '../utils/formatNumber'
 
@@ -31,7 +32,19 @@ export default function OverviewPage() {
   }, [])
 
   if(loading) return <OverviewSkeleton />
-  if (!model) return null
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view overview analytics."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
 
   const { totalRepos } = model
   const isMulti = orgs.length > 1

--- a/src/pages/RepositoriesPage.jsx
+++ b/src/pages/RepositoriesPage.jsx
@@ -55,7 +55,19 @@ export default function RepositoriesPage() {
   const visible = sorted.slice(0, shown)
 
   if(loading) return <RepositorySkeleton />
-  if (!model) return null
+  if (!model) {
+    return (
+      <div style={{ padding: '32px 24px', maxWidth: 900, margin: '0 auto' }}>
+        <EmptyStateCard
+          SvgIcon={<FiDatabase size={36} color="var(--accent)" />}
+          title="No Organization Analyzed"
+          description="Explore an organization on the home page to view repository data."
+          buttonText="Go to Home"
+          onButtonClick={() => navigate('/')}
+        />
+      </div>
+    )
+  }
 
   const TABLE_COLS = [
     ['name', 'Repository'],


### PR DESCRIPTION
Fixes #208 

Overview of Changes:
This PR fixes the bug where refreshing sub-pages (/governance, /overview, /repositories, /contributors, /analytics, /network) wiped React in-memory state and produced a blank black screen.

State Persistence & Auto-Restoration:
Saved active organization selections to localStorage.oe_active_orgs.
Added an initial useEffect in AppContext to automatically re-explore the last active organization on browser refresh while displaying appropriate skeleton loaders.

Empty State UX Fallbacks:
Replaced if (!model) return null across all sub-pages with a consistent EmptyStateCard component that prompts users to explore an organization on the home page.

Recordings:
Before-
[Screencast From 2026-08-30 23-35-48.webm](https://github.com/user-attachments/assets/a1a32791-5927-41bd-96a8-480453a42dad)

After-
[Screencast From 2026-08-30 23-49-20.webm](https://github.com/user-attachments/assets/794d4dd4-2f36-42e7-a5d9-2e59cb9e882b)


Additional Notes:
Prevents blank screen crashes across all sub-routes when refreshing or deep linking.
Built and verified locally using npm run build with zero errors or warnings.

## Checklist
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now remembers recently explored organizations and restores them automatically when reopened.
  * Added clear empty-state screens across analytics, contributors, governance, network, overview, and repositories pages when no organization is analyzed.
  * Empty states include guidance and a convenient “Go to Home” button.

* **Bug Fixes**
  * Improved page handling when organization data is unavailable.
  * Prevented governance pagination from failing when repository statistics are missing.
  * Improved resilience when browser storage is unavailable or contains invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->