### PR TITLE
fix(services): close IndexedDB connections after transactions in github.js

### DIFF
--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -53,9 +53,11 @@ export default function SettingsPage() {
   }
 
   const handleClear = async () => {
-    await cacheClear()
-    setCleared(true)
-    setTimeout(() => setCleared(false), 2000)
+    const success = await cacheClear()
+    if (success) {
+      setCleared(true)
+      setTimeout(() => setCleared(false), 2000)
+    }
   }
 
   const rateColor = rateLimit

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -16,13 +16,27 @@ export async function cacheGet(key) {
   try {
     const db = await openDB()
     return new Promise(res => {
-      const req = db.transaction(STORE, 'readonly').objectStore(STORE).get(key)
+      const tx = db.transaction(STORE, 'readonly')
+      const req = tx.objectStore(STORE).get(key)
+      let value = null
       req.onsuccess = () => {
         const r = req.result
-        if (!r || Date.now() - r.ts > TTL_MS) return res(null)
-        res(r.v)
+        if (r && Date.now() - r.ts <= TTL_MS) {
+          value = r.v
+        }
       }
-      req.onerror = () => res(null)
+      tx.oncomplete = () => {
+        db.close()
+        res(value)
+      }
+      tx.onerror = () => {
+        db.close()
+        res(null)
+      }
+      tx.onabort = () => {
+        db.close()
+        res(null)
+      }
     })
   } catch { return null }
 }
@@ -33,8 +47,18 @@ export async function cacheSet(key, value) {
     return new Promise(res => {
       const tx = db.transaction(STORE, 'readwrite')
       tx.objectStore(STORE).put({ k: key, v: value, ts: Date.now() })
-      tx.oncomplete = () => res(true)
-      tx.onerror = () => res(false)
+      tx.oncomplete = () => {
+        db.close()
+        res(true)
+      }
+      tx.onerror = () => {
+        db.close()
+        res(false)
+      }
+      tx.onabort = () => {
+        db.close()
+        res(false)
+      }
     })
   } catch { return false }
 }
@@ -45,8 +69,18 @@ export async function cacheClear() {
     return new Promise(res => {
       const tx = db.transaction(STORE, 'readwrite')
       tx.objectStore(STORE).clear()
-      tx.oncomplete = () => res(true)
-      tx.onerror = () => res(false)
+      tx.oncomplete = () => {
+        db.close()
+        res(true)
+      }
+      tx.onerror = () => {
+        db.close()
+        res(false)
+      }
+      tx.onabort = () => {
+        db.close()
+        res(false)
+      }
     })
   } catch { return false }
 }


### PR DESCRIPTION
Fixes #216

### Summary of Changes
In `src/services/github.js`, `openDB()` opens an `IDBDatabase` connection handle for cached API queries (`cacheGet`, `cacheSet`, `cacheClear`), but the database handle was not being closed after transaction completion.

This PR adds explicit `db.close()` calls within `tx.oncomplete`, `tx.onerror`, and `tx.onabort` callbacks across all cache service methods.

### Verification
- Tested IndexedDB cache operations for GitHub API requests.
- Verified that database connection handles are properly closed when transactions finalize, preventing memory leaks and handle accumulation in browser DevTools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache read reliability by handling transaction completion, errors, and interruptions consistently.
  * Ensured expired or unavailable cached data returns an empty result instead of stale or incomplete data.
  * Improved cache update and clearing operations when transactions are interrupted.
  * Ensured database connections are closed after cache operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->