### PR TITLE
feat(routes): implement code splitting and lazy loading for application pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,12 @@ const NetworkPage            = React.lazy(() => import('./pages/NetworkPage'))
 const AnalyticsPage          = React.lazy(() => import('./pages/AnalyticsPage'))
 const GovernancePage         = React.lazy(() => import('./pages/GovernancePage'))
 const SettingsPage           = React.lazy(() => import('./pages/SettingsPage'))
-const Support                = React.lazy(() => import('./pages/Support'))
+const ROUTE_STRINGS = {
+  ERROR_TITLE: 'Unable to load page',
+  ERROR_MESSAGE: 'An error occurred while loading this page.',
+  RELOAD_BUTTON: 'Reload Page',
+  LOADING_LABEL: 'Loading page',
+}
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -37,10 +42,10 @@ class ErrorBoundary extends Component {
     if (this.state.hasError) {
       return (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 16px', textAlign: 'center' }}>
-          <h3>Unable to load page</h3>
-          <p style={{ color: 'var(--text2)', marginBottom: '16px' }}>An error occurred while loading this page.</p>
+          <h3>{ROUTE_STRINGS.ERROR_TITLE}</h3>
+          <p style={{ color: 'var(--text2)', marginBottom: '16px' }}>{ROUTE_STRINGS.ERROR_MESSAGE}</p>
           <button className="btn btn-primary" onClick={() => window.location.reload()}>
-            Reload Page
+            {ROUTE_STRINGS.RELOAD_BUTTON}
           </button>
         </div>
       )
@@ -51,7 +56,7 @@ class ErrorBoundary extends Component {
 
 function PageLoader() {
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }} role="status" aria-label="Loading page">
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }} role="status" aria-label={ROUTE_STRINGS.LOADING_LABEL}>
       <Spinner size={36} />
     </div>
   )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,21 +1,61 @@
-import React from 'react'
+import React, { Suspense, Component } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { AppProvider } from './context/AppContext'
 import { ThemeProvider } from './context/ThemeContext'
 import Navbar          from './components/Navbar'
 import RateLimitBanner from './components/RateLimitBanner'
-import HomePage        from './pages/HomePage'
-import OverviewPage    from './pages/OverviewPage'
-import RepositoriesPage from './pages/RepositoriesPage'
-import ContributorsPage from './pages/ContributorsPage'
-import ContributorProfilePage from './pages/ContributorProfilePage'
-import NetworkPage     from './pages/NetworkPage'
-import AnalyticsPage   from './pages/AnalyticsPage'
-import GovernancePage  from './pages/GovernancePage'
-import SettingsPage    from './pages/SettingsPage'
-import Footer from './components/layout/Footer'
-import Support from './pages/Support'
+import Footer          from './components/layout/Footer'
 import RequireAnalysis from './components/RequireAnalysis'
+import { Spinner }     from './components/UI'
+
+const HomePage               = React.lazy(() => import('./pages/HomePage'))
+const OverviewPage           = React.lazy(() => import('./pages/OverviewPage'))
+const RepositoriesPage        = React.lazy(() => import('./pages/RepositoriesPage'))
+const ContributorsPage       = React.lazy(() => import('./pages/ContributorsPage'))
+const ContributorProfilePage = React.lazy(() => import('./pages/ContributorProfilePage'))
+const NetworkPage            = React.lazy(() => import('./pages/NetworkPage'))
+const AnalyticsPage          = React.lazy(() => import('./pages/AnalyticsPage'))
+const GovernancePage         = React.lazy(() => import('./pages/GovernancePage'))
+const SettingsPage           = React.lazy(() => import('./pages/SettingsPage'))
+const Support                = React.lazy(() => import('./pages/Support'))
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Route load error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 16px', textAlign: 'center' }}>
+          <h3>Unable to load page</h3>
+          <p style={{ color: 'var(--text2)', marginBottom: '16px' }}>A network error occurred while loading this section.</p>
+          <button className="btn btn-primary" onClick={() => window.location.reload()}>
+            Reload Page
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+function PageLoader() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }} role="status" aria-label="Loading page">
+      <Spinner size={36} />
+    </div>
+  )
+}
 
 function Layout({ children }) {
   return (
@@ -31,19 +71,23 @@ function Layout({ children }) {
 function AppContent() {
   return (
     <Layout>
-      <Routes>
-        <Route path="/"             element={<HomePage />} />
-        <Route path="/overview"     element={<RequireAnalysis><OverviewPage /></RequireAnalysis>} />
-        <Route path="/repositories" element={<RequireAnalysis><RepositoriesPage /></RequireAnalysis>} />
-        <Route path="/contributors" element={<RequireAnalysis><ContributorsPage /></RequireAnalysis>} />
-        <Route path="/contributors/:username" element={<RequireAnalysis><ContributorProfilePage /></RequireAnalysis>} />
-        <Route path="/network"      element={<RequireAnalysis><NetworkPage /></RequireAnalysis>} />
-        <Route path="/analytics"    element={<RequireAnalysis><AnalyticsPage /></RequireAnalysis>} />
-        <Route path="/governance"   element={<RequireAnalysis><GovernancePage /></RequireAnalysis>} />
-        <Route path="/settings"     element={<SettingsPage />} />
-        <Route path="/support-us"      element={<Support />} />
-        <Route path="*"             element={<Navigate to="/" replace />} />
-      </Routes>
+      <ErrorBoundary>
+        <Suspense fallback={<PageLoader />}>
+          <Routes>
+            <Route path="/"             element={<HomePage />} />
+            <Route path="/overview"     element={<RequireAnalysis><OverviewPage /></RequireAnalysis>} />
+            <Route path="/repositories" element={<RequireAnalysis><RepositoriesPage /></RequireAnalysis>} />
+            <Route path="/contributors" element={<RequireAnalysis><ContributorsPage /></RequireAnalysis>} />
+            <Route path="/contributors/:username" element={<RequireAnalysis><ContributorProfilePage /></RequireAnalysis>} />
+            <Route path="/network"      element={<RequireAnalysis><NetworkPage /></RequireAnalysis>} />
+            <Route path="/analytics"    element={<RequireAnalysis><AnalyticsPage /></RequireAnalysis>} />
+            <Route path="/governance"   element={<RequireAnalysis><GovernancePage /></RequireAnalysis>} />
+            <Route path="/settings"     element={<SettingsPage />} />
+            <Route path="/support-us"   element={<Support />} />
+            <Route path="*"             element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
     </Layout>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ class ErrorBoundary extends Component {
       return (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 16px', textAlign: 'center' }}>
           <h3>Unable to load page</h3>
-          <p style={{ color: 'var(--text2)', marginBottom: '16px' }}>A network error occurred while loading this section.</p>
+          <p style={{ color: 'var(--text2)', marginBottom: '16px' }}>An error occurred while loading this page.</p>
           <button className="btn btn-primary" onClick={() => window.location.reload()}>
             Reload Page
           </button>


### PR DESCRIPTION
Fixes #140

### Summary of Changes
- Replaced static page imports in `src/App.jsx` with `React.lazy()` dynamic imports to split route components into smaller JavaScript chunks.
- Wrapped route components in a `Suspense` boundary using an accessible `Spinner` loading indicator.
- Added an `ErrorBoundary` wrapper to catch and gracefully handle failed dynamic page module imports.

### Verification
- Verified route navigation across all pages.
- Confirmed that page modules load dynamically on demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Pages now load on demand to improve initial application loading speed.

* **User Experience**
  * Added a loading indicator while pages are loading.
  * Added an inline error message with a reload option when a page cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->