### PR TITLE
fix: handle non-array GitHub API responses

### DIFF
--- a/src/services/github.js
+++ b/src/services/github.js
@@ -77,6 +77,7 @@ async function fetchWithCache(url, pat) {
   if (res.status === 404) throw new Error('NOT_FOUND')
   if (!res.ok) throw new Error(`HTTP_${res.status}`)
   if(res.status==204){
+    cacheSet(url, [])
     return[]
   }
   const data = await res.json()

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -76,7 +76,9 @@ async function fetchWithCache(url, pat) {
   if (res.status === 403) throw new Error('RATE_LIMIT')
   if (res.status === 404) throw new Error('NOT_FOUND')
   if (!res.ok) throw new Error(`HTTP_${res.status}`)
-
+  if(res.status==204){
+    return[]
+  }
   const data = await res.json()
   cacheSet(url, data) // write-back, non-blocking
   return data
@@ -104,6 +106,7 @@ export async function fetchContributors(org, repo, pat) {
   for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/contributors?per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
+    if (!Array.isArray(data)) break
     all.push(...data)
     if(data.length < 100) break
   }
@@ -116,6 +119,7 @@ export async function fetchIssues(org, repo, pat) {
   for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/issues?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
+    if (!Array.isArray(data)) break
     all.push(...data)
     if(data.length < 100) break
   }
@@ -128,6 +132,7 @@ export async function fetchPulls(org, repo, pat) {
   for(let page = 1; page<=maxPages ; page++) {
     const url = `https://api.github.com/repos/${org}/${repo}/pulls?state=all&per_page=100&page=${page}`
     const data = await fetchWithCache(url, pat)
+    if (!Array.isArray(data)) break
     all.push(...data)
     if(data.length < 100) break
   }


### PR DESCRIPTION
## Description

Fixes the GitHub API response handling issue described in #225 .

## Changes

- Handle `204 No Content` responses in `fetchWithCache()` by returning an empty array.
- Validate responses from `fetchContributors()`, `fetchIssues()`, and `fetchPulls()` before spreading them into the result array.
- Gracefully stop pagination when GitHub returns a non-array response.

## Problem

Some GitHub API endpoints can return responses that are not arrays.

For example, repositories with disabled Issues can return an object containing a `message` field, while some valid requests can return `204 No Content`.

Previously, these responses could cause:

`TypeError: data is not iterable`

or:

`SyntaxError: Unexpected end of JSON input`

This change prevents those responses from crashing the data-fetching pipeline.

## Testing

- `npm run build` passes successfully.
- `git diff --check` passes successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty GitHub API responses.
  - Prevented contributor, issue, and pull request listings from failing when paginated responses contain no usable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->